### PR TITLE
Changed project name to partagix and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.idea/
+app/.idea/
+
 .DS_Store
 .gradle
 /local.properties
@@ -6,4 +8,6 @@
 /captures
 .externalNativeBuild
 .cxx
+
 local.properties
+google-services.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,6 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Partagix"
+rootProject.name = "partagix"
 include(":app")
  


### PR DESCRIPTION
In order to build, the folder name must match with the project name, which was not the case (due to a lowercase)
+
Added app/.idea and google-services.json to .gitignore