### PR TITLE
Project name with lowercase

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Partagix</string>
+    <string name="app_name">partagix</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
 


### PR DESCRIPTION
All project name instances should be lowercase (except "fun PartagixAppTheme" in Theme.kt as unit returning function should start with an uppercase)