### PR TITLE
Made the NavigationActions easier to use

### DIFF
--- a/app/src/main/java/com/android/partagix/ui/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/partagix/ui/BottomNavigationMenu.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
-import com.android.partagix.ui.navigation.NavigationActions
 import com.android.partagix.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.android.partagix.ui.navigation.TopLevelDestination
 
@@ -33,5 +32,5 @@ fun BottomNavigationBar(
 @Composable
 fun previewScaffold() {
   val navController = rememberNavController()
-  val navigate = NavigationActions::navigateTo
+  // val navigate = NavigationActions::navigateTo
 }

--- a/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
@@ -1,5 +1,7 @@
 package com.android.partagix.ui.navigation
 
+import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -7,6 +9,8 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 object Route {
+  const val LOGIN = "Login"
+  const val HOME = "Home"
   const val INVENTORY = "Inventory"
 }
 
@@ -19,23 +23,32 @@ data class TopLevelDestination(
 class NavigationActions(private val navController: NavHostController) {
 
   fun navigateTo(destination: TopLevelDestination) {
-    navController.navigate(destination.route) {
+    navigateTo(destination.route)
+  }
 
-      // Pop up to the start destination of the graph to
-      // avoid building up a large stack of destinations
-      // on the back stack as users select items
-
-      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-      // Avoid multiple copies of the same destination when
-      // reselecting the same item
+  fun navigateTo(route: String) {
+    navController.navigate(route) {
       launchSingleTop = true
-      // Restore state when reselecting a previously selected item
       restoreState = true
     }
   }
 
   fun goBack() {
-    navigateTo(TOP_LEVEL_DESTINATIONS.first())
+    navController.popBackStack()
+  }
+
+  @SuppressLint("RestrictedApi")
+  fun logNavigationStack() {
+    val stack = navController.currentBackStack.value
+
+    for (i in stack.indices) {
+      val entry = stack[i]
+      Log.d(TAG, "Entry $i: ${entry.destination.route}")
+    }
+  }
+
+  companion object {
+    private const val TAG = "NavigationActions"
   }
 }
 

--- a/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
@@ -5,10 +5,10 @@ import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 object Route {
+  const val BOOT = "Boot"
   const val LOGIN = "Login"
   const val HOME = "Home"
   const val INVENTORY = "Inventory"


### PR DESCRIPTION
Added overload to navigateTo, that excepts also a string as route name (from enum ROUTE) 
Previous version of goBack() didn't go back ? Only to the first destination defined in TOP_LEVEL_DESTINATION ! Fixed it
Also added a useful function (`logNavigationStack()`) that allows to print the content of the stack (easy debug kit)