### PR TITLE
Ab/view account2

### DIFF
--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -47,12 +47,14 @@ class UserViewModel(
     val userID = FirebaseAuth.getInstance().currentUser?.uid
 
     if (userID == null) {
-      println("No user logged-in tried to watch current user profile")
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-    } else {
-
+    } else if (userID != "" && false) { // TODO: remove false when logged in users are in the database
       database.getUser(userID) { updateUIState(it) }
       println("User logged-in tried to watch current user profile : $userID")
+    } else {
+      database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
+      println("User logged-in tried to watch current user profile but no user ID found. Defaulted to grinch user.")
+
     }
   }
 

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.partagix.model
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.partagix.model.inventory.Inventory
+import com.android.partagix.model.user.User
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class UserViewModel(
+    user: User = User("", "", "", "", Inventory("", emptyList())),
+) : ViewModel() {
+
+  // private val user = user
+  private val database = Database()
+
+  // UI state exposed to the UI
+  private val _uiState = MutableStateFlow(UserUIState(user))
+  val uiState: StateFlow<UserUIState> = _uiState
+
+  init {
+    if (user.id == "") {
+      // setUserToCurrent()
+      database.getUser("lzMnQv5a4kpGBsPhRcDS") { updateUIState(it) }
+    } else {
+      updateUIState(user)
+    }
+  }
+
+  private fun setUserToCurrent() {
+    val user = FirebaseAuth.getInstance().currentUser?.uid
+    viewModelScope.launch {
+      if (user == null) {
+        println("No user logged-in tried to watch current user profile")
+      } else {
+        database.getUser(user) { updateUIState(it) }
+      }
+    }
+  }
+
+  private fun updateUIState(new: User) {
+    _uiState.value =
+        _uiState.value.copy(
+            user = new,
+        )
+  }
+
+  companion object {
+    private const val TAG = "UserViewModel"
+  }
+}
+
+data class UserUIState(val user: User)

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -37,21 +37,23 @@ class UserViewModel(
   val uiState: StateFlow<UserUIState> = _uiState
 
   init {
+    println("UserViewModel init")
     if (user.id == "") {
-      // setUserToCurrent()
-      database.getUser("lzMnQv5a4kpGBsPhRcDS") { updateUIState(it) }
+      setUserToCurrent()
     } else {
-      updateUIState(user)
+      database.getUser(user.id) { updateUIState(it) }
     }
   }
 
   private fun setUserToCurrent() {
-    val user = FirebaseAuth.getInstance().currentUser?.uid
+    val userID = FirebaseAuth.getInstance().currentUser?.uid
     viewModelScope.launch {
-      if (user == null) {
+      if (userID == null) {
         println("No user logged-in tried to watch current user profile")
       } else {
-        database.getUser(user) { updateUIState(it) }
+
+        database.getUser(userID) { updateUIState(it) }
+        println("User logged-in tried to watch current user profile : $userID")
       }
     }
   }
@@ -61,6 +63,7 @@ class UserViewModel(
         _uiState.value.copy(
             user = new,
         )
+    println("User updated: $new")
   }
 
   companion object {

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -17,13 +17,11 @@
 package com.android.partagix.model
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.android.partagix.model.inventory.Inventory
 import com.android.partagix.model.user.User
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 class UserViewModel(
     user: User = User("", "", "", "", Inventory("", emptyList())),
@@ -47,14 +45,13 @@ class UserViewModel(
 
   private fun setUserToCurrent() {
     val userID = FirebaseAuth.getInstance().currentUser?.uid
-    viewModelScope.launch {
-      if (userID == null) {
-        println("No user logged-in tried to watch current user profile")
-      } else {
 
-        database.getUser(userID) { updateUIState(it) }
-        println("User logged-in tried to watch current user profile : $userID")
-      }
+    if (userID == null) {
+      println("No user logged-in tried to watch current user profile")
+    } else {
+
+      database.getUser(userID) { updateUIState(it) }
+      println("User logged-in tried to watch current user profile : $userID")
     }
   }
 

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -48,6 +48,7 @@ class UserViewModel(
 
     if (userID == null) {
       println("No user logged-in tried to watch current user profile")
+      database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
     } else {
 
       database.getUser(userID) { updateUIState(it) }

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -35,7 +35,6 @@ class UserViewModel(
   val uiState: StateFlow<UserUIState> = _uiState
 
   init {
-    println("UserViewModel init")
     if (user.id == "") {
       setUserToCurrent()
     } else {
@@ -51,11 +50,8 @@ class UserViewModel(
     } else if (userID != "" &&
         false) { // TODO: remove false when logged in users are in the database
       database.getUser(userID) { updateUIState(it) }
-      println("User logged-in tried to watch current user profile : $userID")
     } else {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-      println(
-          "User logged-in tried to watch current user profile but no user ID found. Defaulted to grinch user.")
     }
   }
 
@@ -64,7 +60,6 @@ class UserViewModel(
         _uiState.value.copy(
             user = new,
         )
-    println("User updated: $new")
   }
 
   companion object {

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -48,13 +48,14 @@ class UserViewModel(
 
     if (userID == null) {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-    } else if (userID != "" && false) { // TODO: remove false when logged in users are in the database
+    } else if (userID != "" &&
+        false) { // TODO: remove false when logged in users are in the database
       database.getUser(userID) { updateUIState(it) }
       println("User logged-in tried to watch current user profile : $userID")
     } else {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-      println("User logged-in tried to watch current user profile but no user ID found. Defaulted to grinch user.")
-
+      println(
+          "User logged-in tried to watch current user profile but no user ID found. Defaulted to grinch user.")
     }
   }
 

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -23,6 +23,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.android.partagix.model.InventoryViewModel
 import com.android.partagix.model.ItemViewModel
+import com.android.partagix.model.UserViewModel
 import com.android.partagix.model.auth.Authentication
 import com.android.partagix.model.auth.SignInResultListener
 import com.android.partagix.ui.navigation.NavigationActions
@@ -125,7 +126,12 @@ class App(activity: MainActivity) : ComponentActivity(), SignInResultListener {
             inventoryViewModel = inventoryViewModel,
             navigateToTopLevelDestination = navigationActions::navigateTo)
       }
-      composable(Route.ACCOUNT) { ViewAccount(navigationActions =navigationActions)}
+      composable(
+          Route.ACCOUNT,) {
+          println("navigated to account screen")
+          ViewAccount(navigationActions =navigationActions, userViewModel = UserViewModel())
+
+      }
       composable(
           Route.VIEW_ITEM + "/{itemId}",
           arguments = listOf(navArgument("itemId") { type = NavType.StringType })) {

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -31,6 +31,7 @@ import com.android.partagix.ui.screens.BootScreen
 import com.android.partagix.ui.screens.HomeScreen
 import com.android.partagix.ui.screens.InventoryScreen
 import com.android.partagix.ui.screens.LoginScreen
+import com.android.partagix.ui.screens.ViewAccount
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.launch
 
@@ -92,7 +93,9 @@ class App(activity: MainActivity) : ComponentActivity(), SignInResultListener {
     Row(modifier = modifier.fillMaxSize()) {
       Column(
           modifier =
-              Modifier.fillMaxSize().background(MaterialTheme.colorScheme.inverseOnSurface)) {
+          Modifier
+              .fillMaxSize()
+              .background(MaterialTheme.colorScheme.inverseOnSurface)) {
             ComposeNavigationHost(
                 navController = navController,
                 modifier = Modifier.weight(1f),
@@ -120,7 +123,7 @@ class App(activity: MainActivity) : ComponentActivity(), SignInResultListener {
             inventoryViewModel = inventoryViewModel,
             navigateToTopLevelDestination = navigationActions::navigateTo)
       }
-      composable(Route.ACCOUNT) { /*AccountScreen()*/}
+      composable(Route.ACCOUNT) { ViewAccount(navigationActions =navigationActions)}
       composable(
           Route.VIEW_ITEM + "/{itemId}",
           arguments = listOf(navArgument("itemId") { type = NavType.StringType })) {

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -96,9 +96,7 @@ class App(activity: MainActivity) : ComponentActivity(), SignInResultListener {
     Row(modifier = modifier.fillMaxSize()) {
       Column(
           modifier =
-          Modifier
-              .fillMaxSize()
-              .background(MaterialTheme.colorScheme.inverseOnSurface)) {
+              Modifier.fillMaxSize().background(MaterialTheme.colorScheme.inverseOnSurface)) {
             ComposeNavigationHost(
                 navController = navController,
                 modifier = Modifier.weight(1f),
@@ -127,10 +125,10 @@ class App(activity: MainActivity) : ComponentActivity(), SignInResultListener {
             navigateToTopLevelDestination = navigationActions::navigateTo)
       }
       composable(
-          Route.ACCOUNT,) {
-          println("navigated to account screen")
-          ViewAccount(navigationActions =navigationActions, userViewModel = UserViewModel())
-
+          Route.ACCOUNT,
+      ) {
+        println("navigated to account screen")
+        ViewAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
       }
       composable(
           Route.VIEW_ITEM + "/{itemId}",

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -52,9 +52,9 @@ import kotlin.math.round
 fun ViewAccount(
     modifier: Modifier = Modifier,
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = UserViewModel(),
+    userViewModel: UserViewModel,
 ) {
-  val uiState by userViewModel.uiState.collectAsStateWithLifecycle()
+  val uiState by userViewModel.uiState.collectAsState()
   var user = uiState.user
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("viewAccount"),
@@ -86,7 +86,8 @@ fun ViewAccount(
                     .verticalScroll(rememberScrollState())
                     .testTag("mainContent")) {
               LaunchedEffect(key1 = uiState) {
-                  user = userViewModel.uiState.value.user
+                  println("refreshed User: $user")
+                  user = uiState.user
 
               }
               Image(

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -1,6 +1,5 @@
 package com.android.partagix.ui.screens
 
-import android.util.Half
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -160,20 +159,21 @@ fun ViewAccount(
                   readOnly = true,
                   leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) })
               Spacer(modifier = Modifier.height(16.dp))
-              Row(modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons"),
+              Row(
+                  modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons"),
                   horizontalArrangement = Arrangement.Absolute.Center) {
-                Button(
-                    onClick = { navigationActions.navigateTo(Route.INVENTORY) },
-                    modifier = Modifier.weight(1f).testTag("inventoryButton")) {
-                      Text("See inventory")
-                    }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = { /*TODO: friends */},
-                    modifier = Modifier.weight(1f).testTag("friendButton")) {
-                      Text("Edit Profile [not yet implemented]")
-                    }
-              }
+                    Button(
+                        onClick = { navigationActions.navigateTo(Route.INVENTORY) },
+                        modifier = Modifier.weight(1f).testTag("inventoryButton")) {
+                          Text("See inventory")
+                        }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = { /*TODO: friends */},
+                        modifier = Modifier.weight(1f).testTag("friendButton")) {
+                          Text("Edit Profile [not yet implemented]")
+                        }
+                  }
             }
       }
 }

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -1,5 +1,6 @@
 package com.android.partagix.ui.screens
 
+import android.util.Half
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -80,11 +81,6 @@ fun ViewAccount(
                     .padding(it)
                     .verticalScroll(rememberScrollState())
                     .testTag("mainContent")) {
-              /*LaunchedEffect(key1 = uiState) {
-                  println("refreshed User: $user")
-                  user = uiState.user
-
-              }*/
               Image(
                   painter =
                       painterResource(
@@ -100,16 +96,15 @@ fun ViewAccount(
                     Text("$username's profile")
                   }
               Spacer(modifier = Modifier.height(16.dp))
-
               TextField(
                   value = user.address,
                   onValueChange = {},
                   label = { Text("Location") },
                   colors =
                       TextFieldDefaults.colors(
-                          focusedIndicatorColor = Color.Gray,
-                          disabledIndicatorColor = Color.Gray,
-                          unfocusedIndicatorColor = Color.Gray,
+                          focusedIndicatorColor = Color.Transparent,
+                          disabledIndicatorColor = Color.Transparent,
+                          unfocusedIndicatorColor = Color.Transparent,
                           focusedContainerColor = Color.Transparent,
                           unfocusedContainerColor = Color.Transparent,
                           disabledContainerColor = Color.Transparent),
@@ -155,9 +150,9 @@ fun ViewAccount(
                   label = { Text("Trust") },
                   colors =
                       TextFieldDefaults.colors(
-                          focusedIndicatorColor = Color.Gray,
-                          disabledIndicatorColor = Color.Gray,
-                          unfocusedIndicatorColor = Color.Gray,
+                          focusedIndicatorColor = Color.Transparent,
+                          disabledIndicatorColor = Color.Transparent,
+                          unfocusedIndicatorColor = Color.Transparent,
                           focusedContainerColor = Color.Transparent,
                           unfocusedContainerColor = Color.Transparent,
                           disabledContainerColor = Color.Transparent),
@@ -165,16 +160,17 @@ fun ViewAccount(
                   readOnly = true,
                   leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) })
               Spacer(modifier = Modifier.height(16.dp))
-              Row(modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons")) {
+              Row(modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons"),
+                  horizontalArrangement = Arrangement.Absolute.Center) {
                 Button(
                     onClick = { navigationActions.navigateTo(Route.INVENTORY) },
-                    modifier = Modifier.fillMaxWidth(0.5f).testTag("inventoryButton")) {
+                    modifier = Modifier.weight(1f).testTag("inventoryButton")) {
                       Text("See inventory")
                     }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = { /*TODO: friends */},
-                    modifier = Modifier.fillMaxWidth().testTag("friendButton")) {
+                    modifier = Modifier.weight(1f).testTag("friendButton")) {
                       Text("Edit Profile [not yet implemented]")
                     }
               }

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -36,9 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.partagix.R
 import com.android.partagix.model.UserViewModel
 import com.android.partagix.ui.components.BottomNavigationBar
@@ -46,7 +43,7 @@ import com.android.partagix.ui.navigation.NavigationActions
 import com.android.partagix.ui.navigation.Route
 import kotlin.math.round
 
-//@Preview(showBackground = true)
+// @Preview(showBackground = true)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ViewAccount(
@@ -54,8 +51,8 @@ fun ViewAccount(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
 ) {
-  val uiState by userViewModel.uiState.collectAsState()
-  var user = uiState.user
+  val uiState = userViewModel.uiState.collectAsState()
+  val user = uiState.value.user
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("viewAccount"),
       topBar = {
@@ -63,9 +60,7 @@ fun ViewAccount(
             title = { Text("My Account") },
             modifier = Modifier.fillMaxWidth().testTag("title"),
             navigationIcon = {
-              IconButton(onClick = {
-                  navigationActions.goBack()
-              }) {
+              IconButton(onClick = { navigationActions.goBack() }) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = null,
@@ -74,22 +69,22 @@ fun ViewAccount(
             })
       },
       bottomBar = {
-          BottomNavigationBar(
-              selectedDestination = Route.ACCOUNT,
-              navigateToTopLevelDestination = navigationActions::navigateTo,
-              modifier = modifier.testTag("accountScreenBottomNavBar"))}
-      ) {
+        BottomNavigationBar(
+            selectedDestination = Route.ACCOUNT,
+            navigateToTopLevelDestination = navigationActions::navigateTo,
+            modifier = modifier.testTag("accountScreenBottomNavBar"))
+      }) {
         Column(
             modifier =
                 Modifier.fillMaxHeight()
                     .padding(it)
                     .verticalScroll(rememberScrollState())
                     .testTag("mainContent")) {
-              LaunchedEffect(key1 = uiState) {
+              /*LaunchedEffect(key1 = uiState) {
                   println("refreshed User: $user")
                   user = uiState.user
 
-              }
+              }*/
               Image(
                   painter =
                       painterResource(

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -1,0 +1,187 @@
+package com.android.partagix.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.android.partagix.R
+import com.android.partagix.model.UserViewModel
+import com.android.partagix.ui.components.BottomNavigationBar
+import com.android.partagix.ui.navigation.NavigationActions
+import com.android.partagix.ui.navigation.Route
+import kotlin.math.round
+
+//@Preview(showBackground = true)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ViewAccount(
+    modifier: Modifier = Modifier,
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel = UserViewModel(),
+) {
+  val uiState by userViewModel.uiState.collectAsStateWithLifecycle()
+  var user = uiState.user
+  Scaffold(
+      modifier = Modifier.fillMaxSize().testTag("viewAccount"),
+      topBar = {
+        TopAppBar(
+            title = { Text("My Account") },
+            modifier = Modifier.fillMaxWidth().testTag("title"),
+            navigationIcon = {
+              IconButton(onClick = {
+                  navigationActions.goBack()
+              }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = null,
+                    modifier = Modifier.width(48.dp))
+              }
+            })
+      },
+      bottomBar = {
+          BottomNavigationBar(
+              selectedDestination = Route.ACCOUNT,
+              navigateToTopLevelDestination = navigationActions::navigateTo,
+              modifier = modifier.testTag("accountScreenBottomNavBar"))}
+      ) {
+        Column(
+            modifier =
+                Modifier.fillMaxHeight()
+                    .padding(it)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("mainContent")) {
+              LaunchedEffect(key1 = uiState) {
+                  user = userViewModel.uiState.value.user
+
+              }
+              Image(
+                  painter =
+                      painterResource(
+                          id = R.drawable.ic_launcher_background) /*TODO: get profile picture*/,
+                  contentDescription = null,
+                  modifier = Modifier.fillMaxWidth().testTag("userImage"),
+                  alignment = Alignment.Center)
+              Spacer(modifier = Modifier.height(8.dp))
+              Row(
+                  modifier = Modifier.fillMaxWidth().testTag("username"),
+                  horizontalArrangement = Arrangement.Absolute.SpaceAround) {
+                    val username = user.name
+                    Text("$username's profile")
+                  }
+              Spacer(modifier = Modifier.height(16.dp))
+
+              TextField(
+                  value = user.address,
+                  onValueChange = {},
+                  label = { Text("Location") },
+                  colors =
+                      TextFieldDefaults.colors(
+                          focusedIndicatorColor = Color.Gray,
+                          disabledIndicatorColor = Color.Gray,
+                          unfocusedIndicatorColor = Color.Gray,
+                          focusedContainerColor = Color.Transparent,
+                          unfocusedContainerColor = Color.Transparent,
+                          disabledContainerColor = Color.Transparent),
+                  modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("location"),
+                  readOnly = true,
+                  leadingIcon = { Icon(Icons.Default.LocationOn, contentDescription = null) })
+              val rank = user.rank
+              val stars: String
+              if (rank == "") {
+                stars = "No trust yet"
+              } else {
+                val rating = round(rank.toFloat() * 100) / 100
+                // val rating = 4.5
+                val roundedRating = round(rating).toInt()
+                stars =
+                    when (roundedRating) {
+                      0 -> {
+                        "☆☆☆☆☆ ($rating/5)"
+                      }
+                      1 -> {
+                        "★☆☆☆☆ ($rating/5)"
+                      }
+                      2 -> {
+                        "★★☆☆☆ ($rating/5)"
+                      }
+                      3 -> {
+                        "★★★☆☆ ($rating/5)"
+                      }
+                      4 -> {
+                        "★★★★☆ ($rating/5)"
+                      }
+                      5 -> {
+                        "★★★★★ ($rating/5)"
+                      }
+                      else -> {
+                        "..."
+                      }
+                    }
+              }
+              TextField(
+                  value = stars,
+                  onValueChange = {},
+                  label = { Text("Trust") },
+                  colors =
+                      TextFieldDefaults.colors(
+                          focusedIndicatorColor = Color.Gray,
+                          disabledIndicatorColor = Color.Gray,
+                          unfocusedIndicatorColor = Color.Gray,
+                          focusedContainerColor = Color.Transparent,
+                          unfocusedContainerColor = Color.Transparent,
+                          disabledContainerColor = Color.Transparent),
+                  modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("rating"),
+                  readOnly = true,
+                  leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) })
+              Spacer(modifier = Modifier.height(16.dp))
+              Row(modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons")) {
+                Button(
+                    onClick = { navigationActions.navigateTo(Route.INVENTORY) },
+                    modifier = Modifier.fillMaxWidth(0.5f).testTag("inventoryButton")) {
+                      Text("See inventory")
+                    }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { /*TODO: friends */},
+                    modifier = Modifier.fillMaxWidth().testTag("friendButton")) {
+                      Text("Edit Profile [not yet implemented]")
+                    }
+              }
+            }
+      }
+}


### PR DESCRIPTION
The UI in ViewAccount should have been merged after this review : https://github.com/EPFLSWENT2024G1/partagix/pull/49#pullrequestreview-1985874067
I apologize for the particularly big PR, it should have been split in 2 after UI was done.

Old stuff : 
ViewAccount screen UI

New stuff : 
Database integration to read user data and fill information to the ViewAccount screen. 

App navigation to the account screen using the bottom NavBar

Note that even though this is working, the database is not currently storing the logged-in users. The default user displayed is actually in the database and not hard-coded. 