### PR TITLE
Added labels + refactored StampScreen slightly

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
@@ -1,10 +1,7 @@
 package com.android.partagix
 
-import android.app.Activity.RESULT_OK
 import android.content.Intent
-import android.net.Uri
 import androidx.core.app.ActivityCompat.startActivityForResult
-import androidx.test.core.app.ActivityScenario
 import com.android.partagix.model.CREATE_PNG_FILE
 import com.android.partagix.model.StampViewModel
 import io.mockk.Runs
@@ -55,6 +52,7 @@ class StampViewModelTests {
     coVerify(exactly = 4) { mockContext.setQrBytes(any()) }
     coVerify(exactly = 4) { startActivityForResult(mockContext, any(), CREATE_PNG_FILE, null) }
   }
+
   @Test
   fun testGenerateQrCodeAndSaveEmptyLabel() {
     val itemId = "testItemId"
@@ -76,5 +74,4 @@ class StampViewModelTests {
     coVerify(exactly = 1) { mockContext.setQrBytes(any()) }
     coVerify(exactly = 1) { startActivityForResult(mockContext, any(), CREATE_PNG_FILE, null) }
   }
-
 }

--- a/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
@@ -1,7 +1,10 @@
 package com.android.partagix
 
+import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.net.Uri
 import androidx.core.app.ActivityCompat.startActivityForResult
+import androidx.test.core.app.ActivityScenario
 import com.android.partagix.model.CREATE_PNG_FILE
 import com.android.partagix.model.StampViewModel
 import io.mockk.Runs
@@ -29,10 +32,10 @@ class StampViewModelTests {
   fun testGenerateQrCodeAndSave() {
     val itemId = "testItemId"
     val label = "testLabel"
-    val small = "Small, XXcm x XXcm (XX per A4 page)"
-    val med = "Medium, XXcm x XXcm (XX per A4 page)"
-    val big = "Big, XXcm x XXcm (XX per A4 page)"
-    val full = "Entire page, XXcm x XXcm (1 per A4 page)"
+    val small = "Small, 5cm x 6cm (18 per A4 page)"
+    val med = "Medium, 8cm x 9cm 6 per A4 page)"
+    val big = "Big, 14cm x 16cm (2 per A4 page)"
+    val full = "Entire page, 20cm x 24cm (1 per A4 page)"
     val intent = slot<Intent>()
 
     every { mockContext.packageName } returns "com.android.partagix"
@@ -52,4 +55,26 @@ class StampViewModelTests {
     coVerify(exactly = 4) { mockContext.setQrBytes(any()) }
     coVerify(exactly = 4) { startActivityForResult(mockContext, any(), CREATE_PNG_FILE, null) }
   }
+  @Test
+  fun testGenerateQrCodeAndSaveEmptyLabel() {
+    val itemId = "testItemId"
+    val label = ""
+
+    val intent = slot<Intent>()
+
+    every { mockContext.packageName } returns "com.android.partagix"
+    every { mockContext.setQrBytes(any()) } just Runs
+    every { startActivityForResult(mockContext, capture(intent), any(), any()) } just Runs
+
+    viewModel.generateQRCodeAndSave(itemId, label, "Small, 5cm x 6cm (18 per A4 page)")
+
+    assert(intent.captured.action == Intent.ACTION_CREATE_DOCUMENT)
+    assert(intent.captured.type == "image/png")
+    assert(intent.captured.getStringExtra(Intent.EXTRA_TITLE) == "qr-code.png")
+    assert(intent.captured.categories.contains(Intent.CATEGORY_OPENABLE))
+
+    coVerify(exactly = 1) { mockContext.setQrBytes(any()) }
+    coVerify(exactly = 1) { startActivityForResult(mockContext, any(), CREATE_PNG_FILE, null) }
+  }
+
 }

--- a/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/StampViewModelTests.kt
@@ -30,7 +30,7 @@ class StampViewModelTests {
     val itemId = "testItemId"
     val label = "testLabel"
     val small = "Small, 5cm x 6cm (18 per A4 page)"
-    val med = "Medium, 8cm x 9cm 6 per A4 page)"
+    val med = "Medium, 8cm x 9cm (6 per A4 page)"
     val big = "Big, 14cm x 16cm (2 per A4 page)"
     val full = "Entire page, 20cm x 24cm (1 per A4 page)"
     val intent = slot<Intent>()
@@ -46,7 +46,7 @@ class StampViewModelTests {
 
     assert(intent.captured.action == Intent.ACTION_CREATE_DOCUMENT)
     assert(intent.captured.type == "image/png")
-    assert(intent.captured.getStringExtra(Intent.EXTRA_TITLE) == "qr-code.png")
+    assert(intent.captured.getStringExtra(Intent.EXTRA_TITLE) == "$label-stamp.png")
     assert(intent.captured.categories.contains(Intent.CATEGORY_OPENABLE))
 
     coVerify(exactly = 4) { mockContext.setQrBytes(any()) }
@@ -68,7 +68,7 @@ class StampViewModelTests {
 
     assert(intent.captured.action == Intent.ACTION_CREATE_DOCUMENT)
     assert(intent.captured.type == "image/png")
-    assert(intent.captured.getStringExtra(Intent.EXTRA_TITLE) == "qr-code.png")
+    assert(intent.captured.getStringExtra(Intent.EXTRA_TITLE) == "stamp.png")
     assert(intent.captured.categories.contains(Intent.CATEGORY_OPENABLE))
 
     coVerify(exactly = 1) { mockContext.setQrBytes(any()) }

--- a/app/src/androidTest/java/com/android/partagix/stamp/StampTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/stamp/StampTest.kt
@@ -13,7 +13,6 @@ import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
-import io.mockk.Awaits
 import io.mockk.Runs
 import io.mockk.coVerify
 import io.mockk.every
@@ -40,7 +39,9 @@ class StampTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
     mockNavActions = mockk<NavigationActions>()
     every { mockNavActions.goBack() } just Runs
 
-    composeTestRule.setContent { StampScreen(Modifier, mockStampViewModel, "123456",  mockNavActions) }
+    composeTestRule.setContent {
+      StampScreen(Modifier, mockStampViewModel, "123456", mockNavActions)
+    }
   }
 
   @Test fun testTest() = run { assert(true) }

--- a/app/src/androidTest/java/com/android/partagix/stamp/StampTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/stamp/StampTest.kt
@@ -13,7 +13,9 @@ import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
+import io.mockk.Awaits
 import io.mockk.Runs
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
@@ -33,11 +35,12 @@ class StampTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
   fun testSetup() {
 
     mockStampViewModel = mockk()
+    every { mockStampViewModel.generateQRCodeAndSave(any(), any(), any()) } returns Unit
 
     mockNavActions = mockk<NavigationActions>()
     every { mockNavActions.goBack() } just Runs
 
-    composeTestRule.setContent { StampScreen(Modifier, mockStampViewModel, mockNavActions) }
+    composeTestRule.setContent { StampScreen(Modifier, mockStampViewModel, "123456",  mockNavActions) }
   }
 
   @Test fun testTest() = run { assert(true) }
@@ -116,5 +119,14 @@ class StampTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
   @Test
   fun downloadButtonIsDisplayed() = run {
     onComposeScreen<StampScreen>(composeTestRule) { downloadButton { assertIsDisplayed() } }
+  }
+
+  @Test
+  fun downloadButtonWorks() = run {
+    onComposeScreen<StampScreen>(composeTestRule) {
+      downloadButton { assertIsDisplayed() }
+      downloadButton { performClick() }
+      coVerify(exactly = 1) { mockStampViewModel.generateQRCodeAndSave("123456", "", any()) }
+    }
   }
 }

--- a/app/src/main/java/com/android/partagix/model/StampViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/StampViewModel.kt
@@ -2,10 +2,17 @@ package com.android.partagix.model
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
 import androidx.core.app.ActivityCompat.startActivityForResult
 import androidx.lifecycle.ViewModel
 import com.android.partagix.MainActivity
 import com.android.partagix.model.stampDimension.StampDimension
+import java.io.ByteArrayOutputStream
 import qrcode.QRCode
 import qrcode.QRCodeBuilder
 
@@ -23,20 +30,76 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
       StampDimension.FULL_PAGE -> qrCodeBuilder.withSize(20)
     }
   }
-  // TODO : add the label to the qr code
-  // private fun addLabel(pngBytes: ByteArray, label: String) {}
+
+  private fun addLabel(pngBytes: ByteArray, label: String, dim: StampDimension): ByteArray {
+    // Convert ByteArray to Bitmap
+    val originalBitmap = BitmapFactory.decodeByteArray(pngBytes, 0, pngBytes.size)
+    val width = originalBitmap.width
+
+    val addedSpace =
+        when (dim) {
+          StampDimension.SMALL -> 40
+          StampDimension.MEDIUM -> 80
+          StampDimension.BIG -> 120
+          StampDimension.FULL_PAGE -> 200
+        }
+    val height = originalBitmap.height + addedSpace
+
+    val mutableBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+    // Create a Canvas object with the Bitmap
+    val canvas = Canvas(mutableBitmap)
+
+    // Paint the new bottom part white
+    canvas.drawColor(Color.WHITE)
+
+    // Create a Paint object for drawing text
+    val paint = Paint()
+    paint.color = Color.BLACK // Text color
+    paint.textSize =
+        when (dim) {
+          StampDimension.SMALL -> 20f
+          StampDimension.MEDIUM -> 40f
+          StampDimension.BIG -> 60f
+          StampDimension.FULL_PAGE -> 80f
+        }
+    paint.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD) // Text style
+
+    // Calculate text position (you can adjust this according to your requirement)
+    val textWidth = paint.measureText(label)
+    val x = (width - textWidth) / 2
+    val y = originalBitmap.height + addedSpace * 0.6f
+
+    // Draw the original image onto the Canvas
+    canvas.drawBitmap(originalBitmap, 0f, 0f, null)
+
+    // Draw text onto the Canvas
+    canvas.drawText(label, x, y, paint)
+
+    // Convert Bitmap back to ByteArray
+    val outputStream = ByteArrayOutputStream()
+    mutableBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+    return outputStream.toByteArray()
+  }
 
   fun generateQRCodeAndSave(itemId: String, label: String, detailedDimension: String) {
     val dim = getStampDimension(detailedDimension)
     setSize(qrCodeBuilder, dim)
     val qrCode = qrCodeBuilder.build(itemId).renderToBytes()
+    val qrCodeWithLabel =
+        if (label != "") {
+          addLabel(qrCode, label, dim)
+        } else {
+          qrCode
+        }
+
     val intent =
         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
           addCategory(Intent.CATEGORY_OPENABLE)
           type = "image/png"
         }
     intent.putExtra(Intent.EXTRA_TITLE, "qr-code.png")
-    context.setQrBytes(qrCode)
+    context.setQrBytes(qrCodeWithLabel)
     startActivityForResult(context, intent, CREATE_PNG_FILE, null)
   }
 

--- a/app/src/main/java/com/android/partagix/model/StampViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/StampViewModel.kt
@@ -97,10 +97,8 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
           addCategory(Intent.CATEGORY_OPENABLE)
           type = "image/png"
         }
-    if (label == "")
-      intent.putExtra(Intent.EXTRA_TITLE, "stamp.png")
-    else
-      intent.putExtra(Intent.EXTRA_TITLE, "$label-stamp.png")
+    if (label == "") intent.putExtra(Intent.EXTRA_TITLE, "stamp.png")
+    else intent.putExtra(Intent.EXTRA_TITLE, "$label-stamp.png")
     context.setQrBytes(qrCodeWithLabel)
     startActivityForResult(context, intent, CREATE_PNG_FILE, null)
   }

--- a/app/src/main/java/com/android/partagix/model/StampViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/StampViewModel.kt
@@ -20,7 +20,7 @@ const val CREATE_PNG_FILE = 50
 
 class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainActivity) :
     ViewModel() {
-  private val qrCodeBuilder = QRCode.ofRoundedSquares()
+  private val qrCodeBuilder = QRCode.ofSquares()
 
   private fun setSize(qrCodeBuilder: QRCodeBuilder, dim: StampDimension) {
     when (dim) {
@@ -92,7 +92,6 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
         } else {
           qrCode
         }
-
     val intent =
         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
           addCategory(Intent.CATEGORY_OPENABLE)

--- a/app/src/main/java/com/android/partagix/model/StampViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/StampViewModel.kt
@@ -97,7 +97,10 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
           addCategory(Intent.CATEGORY_OPENABLE)
           type = "image/png"
         }
-    intent.putExtra(Intent.EXTRA_TITLE, "$label-stamp.png")
+    if (label == "")
+      intent.putExtra(Intent.EXTRA_TITLE, "stamp.png")
+    else
+      intent.putExtra(Intent.EXTRA_TITLE, "$label-stamp.png")
     context.setQrBytes(qrCodeWithLabel)
     startActivityForResult(context, intent, CREATE_PNG_FILE, null)
   }

--- a/app/src/main/java/com/android/partagix/model/StampViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/StampViewModel.kt
@@ -53,7 +53,7 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
     // Paint the new bottom part white
     canvas.drawColor(Color.WHITE)
 
-    // Create a Paint object for drawing text
+    // Create a Paint object for drawing text. TODO : adapt text size to the length of the string
     val paint = Paint()
     paint.color = Color.BLACK // Text color
     paint.textSize =
@@ -65,7 +65,7 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
         }
     paint.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD) // Text style
 
-    // Calculate text position (you can adjust this according to your requirement)
+    // Calculate text position
     val textWidth = paint.measureText(label)
     val x = (width - textWidth) / 2
     val y = originalBitmap.height + addedSpace * 0.6f
@@ -97,7 +97,7 @@ class StampViewModel(@SuppressLint("StaticFieldLeak") private val context: MainA
           addCategory(Intent.CATEGORY_OPENABLE)
           type = "image/png"
         }
-    intent.putExtra(Intent.EXTRA_TITLE, "qr-code.png")
+    intent.putExtra(Intent.EXTRA_TITLE, "$label-stamp.png")
     context.setQrBytes(qrCodeWithLabel)
     startActivityForResult(context, intent, CREATE_PNG_FILE, null)
   }

--- a/app/src/main/java/com/android/partagix/model/stampDimension/StampDimension.kt
+++ b/app/src/main/java/com/android/partagix/model/stampDimension/StampDimension.kt
@@ -1,8 +1,8 @@
 package com.android.partagix.model.stampDimension
 
 enum class StampDimension(val detailedDimension: String) {
-  SMALL("Small, XXcm x XXcm (XX per A4 page)"), // ordinal = 0
-  MEDIUM("Medium, XXcm x XXcm (XX per A4 page)"), // ordinal = 1
-  BIG("Big, XXcm x XXcm (XX per A4 page)"), // ordinal = 2
-  FULL_PAGE("Entire page, XXcm x XXcm (1 per A4 page)") // ordinal = 3
+  SMALL("Small, 5cm x 6cm (18 per A4 page)"), // ordinal = 0
+  MEDIUM("Medium, 8cm x 9cm 6 per A4 page)"), // ordinal = 1
+  BIG("Big, 14cm x 16cm (2 per A4 page)"), // ordinal = 2
+  FULL_PAGE("Entire page, 20cm x 24cm (1 per A4 page)") // ordinal = 3
 }

--- a/app/src/main/java/com/android/partagix/model/stampDimension/StampDimension.kt
+++ b/app/src/main/java/com/android/partagix/model/stampDimension/StampDimension.kt
@@ -2,7 +2,7 @@ package com.android.partagix.model.stampDimension
 
 enum class StampDimension(val detailedDimension: String) {
   SMALL("Small, 5cm x 6cm (18 per A4 page)"), // ordinal = 0
-  MEDIUM("Medium, 8cm x 9cm 6 per A4 page)"), // ordinal = 1
+  MEDIUM("Medium, 8cm x 9cm (6 per A4 page)"), // ordinal = 1
   BIG("Big, 14cm x 16cm (2 per A4 page)"), // ordinal = 2
   FULL_PAGE("Entire page, 20cm x 24cm (1 per A4 page)") // ordinal = 3
 }

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -218,6 +218,7 @@ class App(
             StampScreen(
                 modifier = modifier,
                 stampViewModel = StampViewModel(activity),
+                itemID = it.arguments?.getString("itemId") ?: "",
                 navigationActions = navigationActions)
           }
     }

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -191,7 +191,7 @@ fun InventoryCreateOrEditItem(
 
             Row(modifier = modifier.fillMaxWidth()) {
               Button(
-                  onClick = { navigationActions.navigateTo(Route.STAMP) },
+                  onClick = { navigationActions.navigateTo(Route.STAMP + uiName) },
                   content = { Text("Download QR code") },
                   modifier = modifier.fillMaxWidth())
             }

--- a/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
@@ -38,6 +38,7 @@ import com.android.partagix.ui.navigation.NavigationActions
 fun StampScreen(
     modifier: Modifier = Modifier,
     stampViewModel: StampViewModel,
+    itemID : String,
     navigationActions: NavigationActions,
 ) {
   val MAX_LABEL_LENGTH = 40
@@ -95,10 +96,9 @@ fun StampScreen(
                     modifier = modifier.fillMaxWidth().testTag("downloadButton"),
                     onClick = {
                       stampViewModel.generateQRCodeAndSave(
-                          "ZQWESXRDCFTVGY42",
+                          itemID,
                           uiLabel,
-                          uiDetailedDimension) // TODO: have a clean way for the viewmodel to get
-                      // the itemId, without relying on the ui to pass it.
+                          uiDetailedDimension)
                       navigationActions.goBack()
                     },
                     content = { Text("Download stamps") })

--- a/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
@@ -38,7 +38,7 @@ import com.android.partagix.ui.navigation.NavigationActions
 fun StampScreen(
     modifier: Modifier = Modifier,
     stampViewModel: StampViewModel,
-    itemID : String,
+    itemID: String,
     navigationActions: NavigationActions,
 ) {
   val MAX_LABEL_LENGTH = 40
@@ -95,10 +95,7 @@ fun StampScreen(
                 Button(
                     modifier = modifier.fillMaxWidth().testTag("downloadButton"),
                     onClick = {
-                      stampViewModel.generateQRCodeAndSave(
-                          itemID,
-                          uiLabel,
-                          uiDetailedDimension)
+                      stampViewModel.generateQRCodeAndSave(itemID, uiLabel, uiDetailedDimension)
                       navigationActions.goBack()
                     },
                     content = { Text("Download stamps") })

--- a/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/StampScreen.kt
@@ -32,6 +32,8 @@ import com.android.partagix.ui.components.DropDown
 import com.android.partagix.ui.components.StampDimensions
 import com.android.partagix.ui.navigation.NavigationActions
 
+const val MAX_LABEL_LENGTH = 20
+
 /**  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,8 +43,6 @@ fun StampScreen(
     itemID: String,
     navigationActions: NavigationActions,
 ) {
-  val MAX_LABEL_LENGTH = 40
-
   Scaffold(
       modifier = modifier.fillMaxWidth().testTag("stampScreen"),
       topBar = {


### PR DESCRIPTION
StampScreen now takes the itemId as argument, refactored some tests to adapt to this.

QRCodes are now saved with user-defined labels.