### PR TITLE
Fix issue #147

### DIFF
--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -118,7 +118,11 @@ fun InventoryCreateOrEditItem(
               Column {
                 OutlinedTextField(
                     value = uiName,
-                    onValueChange = { it -> uiName = it },
+                    onValueChange = { input ->
+                      // Filter out newline characters from the input string
+                      val filteredInput = input.replace("\n", "")
+                      uiName = filteredInput
+                    },
                     label = { Text("Object name") },
                     modifier = modifier.testTag("name").fillMaxWidth(),
                     readOnly = false)

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -125,6 +125,7 @@ fun InventoryCreateOrEditItem(
                     },
                     label = { Text("Object name") },
                     modifier = modifier.testTag("name").fillMaxWidth(),
+                    maxLines = 1, // Ensure only one line is displayed
                     readOnly = false)
 
                 OutlinedTextField(


### PR DESCRIPTION
Users can't insert any \n on the title of the object they want to edit
If they insert more characters that a line can support they won't be any \n