### PR TITLE
README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![CI Status](https://github.com/EPFLSWENT2024G1/partagix/actions/workflows/ci.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=line_coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
+
 
 
 # PartageIx

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![CI Status](https://github.com/EPFLSWENT2024G1/partagix/actions/workflows/ci.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=line_coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
-
 
 
 # PartageIx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
+![CI Status](https://github.com/github/docs/actions/workflows/ci.yml/badge.svg)
+
+
 # PartageIx
 #Architecture Diagram
 ![image](https://github.com/EPFLSWENT2024G1/partagix/assets/160724066/f3297477-a705-4b8b-b8e4-3e1e2a08236a)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![CI Status](https://github.com/EPFLSWENT2024G1/partagix/actions/workflows/ci.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
+![Line coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsonarcloud.io%2Fapi%2Fqualitygates%2Fproject_status%3FprojectKey%3DEPFLSWENT2024G1_partageix&query=%24.projectStatus.conditions%5B4%5D.actualValue&suffix=%25&label=Line%20Coverage&link=https%3A%2F%2Fsonarcloud.io%2Fcomponent_measures%3Fid%3DEPFLSWENT2024G1_partageix%26metric%3Dnew_line_coverage)
+
 
 
 # PartageIx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+![CI Status](https://github.com/EPFLSWENT2024G1/partagix/actions/workflows/ci.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=EPFLSWENT2024G1_partageix&metric=coverage)](https://sonarcloud.io/summary/new_code?id=EPFLSWENT2024G1_partageix)
-![CI Status](https://github.com/github/docs/actions/workflows/ci.yml/badge.svg)
 
 
 # PartageIx


### PR DESCRIPTION
I added badges to the README to have an overview of the project status on the main github page.

There is no badge for the line coverage on SonarCloud, only for the normal coverage but I'll try to find a way to display the line coverage.