### PR TITLE
Removed the "download QR code" button on both create and edit screen. Fix unique edit per item issue.

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/navigation/EndToEnd.kt
+++ b/app/src/androidTest/java/com/android/partagix/navigation/EndToEnd.kt
@@ -37,7 +37,6 @@ class EndToEnd {
 
     // Wait for the activity to be in the resumed state
     scenario.moveToState(Lifecycle.State.RESUMED)
-    composeTestRule.waitUntil { composeTestRule.onNodeWithText("Home").isDisplayed() }
 
     composeTestRule.waitUntil(timeWait) { composeTestRule.onNodeWithText("Home").isDisplayed() }
     // check that the bottom bar is well displayed

--- a/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
@@ -54,9 +54,20 @@ class ItemViewModel(
    * @param new the new item to update the UI state with
    */
   fun updateUiState(new: Item) {
+    val newWithUserId =
+        Item(
+            new.id,
+            new.category,
+            new.name,
+            new.description,
+            new.visibility,
+            new.quantity,
+            new.location,
+            FirebaseAuth.getInstance().currentUser!!.uid)
+
     _uiState.value =
         _uiState.value.copy(
-            item = new,
+            item = newWithUserId,
         )
   }
 

--- a/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
@@ -18,10 +18,10 @@ package com.android.partagix.model
 
 import android.location.Location
 import androidx.lifecycle.ViewModel
+import com.android.partagix.model.auth.Authentication
 import com.android.partagix.model.category.Category
 import com.android.partagix.model.item.Item
 import com.android.partagix.model.visibility.Visibility
-import com.android.partagix.model.auth.Authentication
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +66,7 @@ class ItemViewModel(
             new.visibility,
             new.quantity,
             new.location,
-            FirebaseAuth.getInstance().currentUser!!.uid)
+            FirebaseAuth.getInstance().currentUser?.uid ?: "")
 
     _uiState.value =
         _uiState.value.copy(
@@ -97,7 +97,7 @@ class ItemViewModel(
     }
   }
 
-  /** Compare 2 given IDs, here the id of the item's user and the id of the current user */
+  /* Compare 2 given IDs, here the id of the item's user and the id of the current user */
   fun compareIDs(id: String, userId: String?): Boolean {
     return id == userId
   }

--- a/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import com.android.partagix.model.category.Category
 import com.android.partagix.model.item.Item
 import com.android.partagix.model.visibility.Visibility
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,7 +44,7 @@ class ItemViewModel(
     if (id != null) {
       database.getItem(id) { newItem -> updateUiState(newItem) }
     } else {
-      updateUiState(item)
+      updateUiState(item) // todo : make it dependent of if the user is logged in
     }
     // TODO: set the author field as the User's name
   }

--- a/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
@@ -44,9 +44,7 @@ class ItemViewModel(
     if (id != null) {
       database.getItem(id) { newItem -> updateUiState(newItem) }
     } else {
-      if (Authentication.getUser() != null) {
-        updateUiState(item)
-      }
+      updateUiState(item)
     }
     // TODO: set the author field as the User's name
   }
@@ -57,6 +55,11 @@ class ItemViewModel(
    * @param new the new item to update the UI state with
    */
   fun updateUiState(new: Item) {
+    var newUserId = ""
+    if (Authentication.getUser() != null) {
+      newUserId = FirebaseAuth.getInstance().currentUser!!.uid
+    }
+
     val newWithUserId =
         Item(
             new.id,
@@ -66,7 +69,7 @@ class ItemViewModel(
             new.visibility,
             new.quantity,
             new.location,
-            FirebaseAuth.getInstance().currentUser?.uid ?: "")
+            newUserId)
 
     _uiState.value =
         _uiState.value.copy(

--- a/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ItemViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.ViewModel
 import com.android.partagix.model.category.Category
 import com.android.partagix.model.item.Item
 import com.android.partagix.model.visibility.Visibility
-import com.google.firebase.Firebase
+import com.android.partagix.model.auth.Authentication
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -44,7 +44,9 @@ class ItemViewModel(
     if (id != null) {
       database.getItem(id) { newItem -> updateUiState(newItem) }
     } else {
-      updateUiState(item) // todo : make it dependent of if the user is logged in
+      if (Authentication.getUser() != null) {
+        updateUiState(item)
+      }
     }
     // TODO: set the author field as the User's name
   }

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -45,7 +45,6 @@ import com.android.partagix.ui.components.DropDown
 import com.android.partagix.ui.components.MainImagePicker
 import com.android.partagix.ui.components.VisibilityItems
 import com.android.partagix.ui.navigation.NavigationActions
-import com.android.partagix.ui.navigation.Route
 
 /**
  * Screen to create a new item in user's inventory.
@@ -195,17 +194,6 @@ fun InventoryCreateOrEditItem(
                 modifier = modifier.fillMaxWidth(),
                 readOnly = false)
 
-            Spacer(modifier = modifier.height(8.dp))
-
-            Row(modifier = modifier.fillMaxWidth()) {
-              Button(
-                  onClick = { navigationActions.navigateTo(Route.STAMP + uiName) },
-                  content = { Text("Download QR code") },
-                  modifier = modifier.fillMaxWidth())
-            }
-
-            Spacer(modifier = modifier.width(8.dp))
-
             Button(
                 onClick = {
                   var id = ""
@@ -230,7 +218,7 @@ fun InventoryCreateOrEditItem(
                     Text("Create")
                   }
                 },
-                modifier = modifier.fillMaxWidth().testTag("button"))
+                modifier = modifier.fillMaxWidth().testTag("button").padding(top = 8.dp))
           }
         }
   }


### PR DESCRIPTION
Removed the "download QR code" button on both create and edit screen, since their irrelevant and one should only download the stamps on ViewItem.

Fixed an issue causing the userId field of an item to be erased once the item is edited. This fix does not pass the end-to-end tests for now, since there is no firebase account when testing in the mock environment.