### PR TITLE
InventoryViewItem signature refactor 

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
@@ -28,7 +28,7 @@ import com.android.partagix.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.android.partagix.ui.screens.HomeScreen
 import com.android.partagix.ui.screens.InventoryCreateOrEditItem
 import com.android.partagix.ui.screens.InventoryScreen
-import com.android.partagix.ui.screens.InventoryViewItem
+import com.android.partagix.ui.screens.InventoryViewItemScreen
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.google.firebase.auth.FirebaseUser
 import io.mockk.Runs
@@ -62,7 +62,7 @@ class EndToEndCreateEdit {
   private lateinit var mockItemUiState3: MutableStateFlow<ItemUIState>
 
   val cat1 = Category("1", "Category 1")
-  val vis1 = com.android.partagix.model.visibility.Visibility.FRIENDS
+  val vis1 = Visibility.FRIENDS
   val loc1 = Location("")
   val items = emptyList<Item>()
   val item2 = Item("1234", cat1, "Object 1", "Description 1", vis1, 2, loc1)
@@ -214,10 +214,7 @@ class EndToEndCreateEdit {
     every { mockItemViewModel.uiState } returns mockItemUiState2
 
     composeTestRule.setContent {
-      InventoryViewItem(
-          navigationActions = mockNavActions,
-          viewModel = mockItemViewModel,
-          stampViewModel = mockStampViewModel)
+      InventoryViewItemScreen(navigationActions = mockNavActions, viewModel = mockItemViewModel)
     }
 
     composeTestRule.onNodeWithText("Object 1").assertIsDisplayed()
@@ -260,10 +257,7 @@ class EndToEndCreateEdit {
     every { mockItemViewModel.uiState } returns mockItemUiState3
 
     composeTestRule.setContent {
-      InventoryViewItem(
-          navigationActions = mockNavActions,
-          viewModel = mockItemViewModel,
-          stampViewModel = mockStampViewModel)
+      InventoryViewItemScreen(navigationActions = mockNavActions, viewModel = mockItemViewModel)
     }
 
     composeTestRule.onNodeWithText("Object 1 edited").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
@@ -1,10 +1,9 @@
-package com.android.partagix.item
+package com.android.partagix.inventory
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.partagix.model.ItemUIState
 import com.android.partagix.model.ItemViewModel
-import com.android.partagix.model.StampViewModel
 import com.android.partagix.model.category.Category
 import com.android.partagix.model.item.Item
 import com.android.partagix.model.visibility.Visibility
@@ -29,7 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ItemTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+class InventoryViewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
@@ -56,9 +56,7 @@ class InventoryViewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
     every { mockNavActions.navigateTo(Route.HOME) } just Runs
     every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
 
-    composeTestRule.setContent {
-      InventoryViewItemScreen(mockNavActions, mockItemViewModel)
-    }
+    composeTestRule.setContent { InventoryViewItemScreen(mockNavActions, mockItemViewModel) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryViewTest.kt
@@ -7,10 +7,10 @@ import com.android.partagix.model.ItemViewModel
 import com.android.partagix.model.category.Category
 import com.android.partagix.model.item.Item
 import com.android.partagix.model.visibility.Visibility
-import com.android.partagix.screens.InventoryViewItem
+import com.android.partagix.screens.InventoryViewItemScreen
 import com.android.partagix.ui.navigation.NavigationActions
 import com.android.partagix.ui.navigation.Route
-import com.android.partagix.ui.screens.InventoryViewItem
+import com.android.partagix.ui.screens.InventoryViewItemScreen
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -57,7 +57,7 @@ class InventoryViewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
     every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
 
     composeTestRule.setContent {
-      InventoryViewItem(mockNavActions, mockItemViewModel)
+      InventoryViewItemScreen(mockNavActions, mockItemViewModel)
     }
   }
 
@@ -68,12 +68,12 @@ class InventoryViewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
 
   @Test
   fun topBarIsDisplayed() = run {
-    onComposeScreen<InventoryViewItem>(composeTestRule) { topBar { assertIsDisplayed() } }
+    onComposeScreen<InventoryViewItemScreen>(composeTestRule) { topBar { assertIsDisplayed() } }
   }
 
   @Test
   fun bottomBarIsDisplayed() = run {
-    onComposeScreen<InventoryViewItem>(composeTestRule) { bottomBar { assertIsDisplayed() } }
+    onComposeScreen<InventoryViewItemScreen>(composeTestRule) { bottomBar { assertIsDisplayed() } }
   }
 
   @Test
@@ -89,6 +89,6 @@ class InventoryViewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
             quantity = 1,
             location = mockk(),
             idUser = "id_user")
-    onComposeScreen<InventoryViewItem>(composeTestRule) { assertIsDisplayed() }
+    onComposeScreen<InventoryViewItemScreen>(composeTestRule) { assertIsDisplayed() }
   }
 }

--- a/app/src/androidTest/java/com/android/partagix/item/ItemTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/item/ItemTests.kt
@@ -34,7 +34,6 @@ class ItemTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
   @RelaxedMockK lateinit var mockItemViewModel: ItemViewModel
-  @RelaxedMockK lateinit var mockStampViewModel: StampViewModel
 
   private var item1: Item =
       Item(
@@ -54,14 +53,12 @@ class ItemTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
     mockItemViewModel = mockk()
     every { mockItemViewModel.uiState } returns mockUiState
 
-    mockStampViewModel = mockk()
-
     mockNavActions = mockk<NavigationActions>()
     every { mockNavActions.navigateTo(Route.HOME) } just Runs
     every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
 
     composeTestRule.setContent {
-      InventoryViewItem(mockNavActions, mockItemViewModel, mockStampViewModel)
+      InventoryViewItem(mockNavActions, mockItemViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/android/partagix/screens/InventoryViewItem.kt
+++ b/app/src/androidTest/java/com/android/partagix/screens/InventoryViewItem.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 
-class InventoryViewItem(semanticsProvider: SemanticsNodeInteractionsProvider) :
-    ComposeScreen<InventoryViewItem>(
+class InventoryViewItemScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<InventoryViewItemScreen>(
         semanticsProvider = semanticsProvider,
         viewBuilderAction = { hasTestTag("inventoryViewItem") }) {
 

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -41,7 +41,7 @@ import com.android.partagix.ui.screens.BootScreen
 import com.android.partagix.ui.screens.HomeScreen
 import com.android.partagix.ui.screens.InventoryCreateOrEditItem
 import com.android.partagix.ui.screens.InventoryScreen
-import com.android.partagix.ui.screens.InventoryViewItem
+import com.android.partagix.ui.screens.InventoryViewItemScreen
 import com.android.partagix.ui.screens.LoanScreen
 import com.android.partagix.ui.screens.LoginScreen
 import com.android.partagix.ui.screens.StampScreen
@@ -226,7 +226,7 @@ class App(
         ViewAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
       }
       composable(Route.VIEW_ITEM) {
-        InventoryViewItem(navigationActions, itemViewModel)
+        InventoryViewItemScreen(navigationActions, itemViewModel)
       }
       composable(Route.CREATE_ITEM) {
         InventoryCreateOrEditItem(itemViewModel, navigationActions, mode = "create")

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -72,7 +71,6 @@ class App(
           onItemCreated = { item -> inventoryViewModel.createItem(item) },
       )
   private val userViewModel = UserViewModel(db = db)
-  private val stampViewModel = StampViewModel(activity)
 
   @Composable
   fun Create() {
@@ -225,9 +223,7 @@ class App(
       ) {
         ViewAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
       }
-      composable(Route.VIEW_ITEM) {
-        InventoryViewItemScreen(navigationActions, itemViewModel)
-      }
+      composable(Route.VIEW_ITEM) { InventoryViewItemScreen(navigationActions, itemViewModel) }
       composable(Route.CREATE_ITEM) {
         InventoryCreateOrEditItem(itemViewModel, navigationActions, mode = "create")
       }

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -226,7 +226,7 @@ class App(
         ViewAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
       }
       composable(Route.VIEW_ITEM) {
-        InventoryViewItem(navigationActions, itemViewModel, stampViewModel)
+        InventoryViewItem(navigationActions, itemViewModel)
       }
       composable(Route.CREATE_ITEM) {
         InventoryCreateOrEditItem(itemViewModel, navigationActions, mode = "create")

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -53,10 +53,7 @@ import com.google.firebase.auth.FirebaseAuth
 @SuppressLint("StateFlowValueCalledInComposition")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun InventoryViewItemScreen(
-    navigationActions: NavigationActions,
-    viewModel: ItemViewModel
-) {
+fun InventoryViewItemScreen(navigationActions: NavigationActions, viewModel: ItemViewModel) {
   val uiState = viewModel.uiState.collectAsState()
 
   var item = uiState.value.item

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.partagix.R
 import com.android.partagix.model.ItemViewModel
-import com.android.partagix.model.StampViewModel
 import com.android.partagix.ui.components.BottomNavigationBar
 import com.android.partagix.ui.components.LabeledText
 import com.android.partagix.ui.navigation.NavigationActions
@@ -56,8 +55,7 @@ import com.google.firebase.auth.FirebaseAuth
 @Composable
 fun InventoryViewItem(
     navigationActions: NavigationActions,
-    viewModel: ItemViewModel,
-    stampViewModel: StampViewModel
+    viewModel: ItemViewModel
 ) {
   val uiState = viewModel.uiState.collectAsState()
 

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -53,7 +53,7 @@ import com.google.firebase.auth.FirebaseAuth
 @SuppressLint("StateFlowValueCalledInComposition")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun InventoryViewItem(
+fun InventoryViewItemScreen(
     navigationActions: NavigationActions,
     viewModel: ItemViewModel
 ) {


### PR DESCRIPTION
Removed the unused StampViewModel argument in the component signature.
Rename the component and the file, from InventoryViewItem to InventoryViewItemScreen.
Updated tests accordingly.