### PR TITLE
'EditAccount' screen

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
@@ -1,0 +1,151 @@
+package com.android.partagix.editAccount
+
+import android.location.Location
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.partagix.model.UserUIState
+import com.android.partagix.model.UserViewModel
+import com.android.partagix.model.category.Category
+import com.android.partagix.model.inventory.Inventory
+import com.android.partagix.model.item.Item
+import com.android.partagix.model.user.User
+import com.android.partagix.screens.EditAccount
+import com.android.partagix.ui.navigation.NavigationActions
+import com.android.partagix.ui.navigation.Route
+import com.android.partagix.ui.screens.EditAccount
+import com.google.common.base.Verify.verify
+import com.kaspersky.components.composesupport.config.withComposeSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+
+  @RelaxedMockK lateinit var mockUserViewModel: UserViewModel
+
+  private lateinit var emptyMockUiState: MutableStateFlow<UserUIState>
+  private lateinit var nonEmptyMockUiState: MutableStateFlow<UserUIState>
+
+  val cat1 = Category("1", "Category 1")
+  val vis1 = com.android.partagix.model.visibility.Visibility.PUBLIC
+  val loc1 = Location("1")
+
+  private val userOne: User =
+      User(
+          "id1",
+          "name1",
+          "address1",
+          "rank1",
+          Inventory("id1", listOf(Item("1", cat1, "Name 1", "Description 1", vis1, 1, loc1))))
+
+  @Before
+  fun testSetup() {
+    nonEmptyMockUiState = MutableStateFlow(UserUIState(userOne))
+
+    mockUserViewModel = mockk()
+    every { mockUserViewModel.updateUser(any()) } just Runs
+
+    mockNavActions = mockk<NavigationActions>()
+    every { mockNavActions.navigateTo(Route.HOME) } just Runs
+    every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
+    every { mockNavActions.navigateTo(Route.ACCOUNT) } just Runs
+    every { mockNavActions.navigateTo(Route.INVENTORY) } just Runs
+    every { mockNavActions.navigateTo(Route.LOAN) } just Runs
+    every { mockNavActions.navigateTo(Route.BOOT) } just Runs
+    every { mockNavActions.navigateTo(Route.VIEW_ITEM) } just Runs
+    every { mockNavActions.goBack() } just Runs
+  }
+
+  @Test
+  fun isDisplayedGoodUser() {
+    every { mockUserViewModel.uiState } returns nonEmptyMockUiState
+    every { mockUserViewModel.getLoggedUserId() } returns "id1"
+    composeTestRule.setContent {
+      EditAccount(
+          modifier = Modifier,
+          userViewModel = mockUserViewModel,
+          navigationActions = mockNavActions)
+    }
+
+    ComposeScreen.onComposeScreen<EditAccount>(composeTestRule) {
+      topBar { assertIsDisplayed() }
+      backButton { assertIsDisplayed() }
+      bottomNavBar { assertIsDisplayed() }
+      mainContent { assertIsDisplayed() }
+      userImage { assertIsDisplayed() }
+      username { assertIsDisplayed() }
+      usernameField { assertIsDisplayed() }
+      addressField { assertIsDisplayed() }
+      actionButtons { assertIsDisplayed() }
+      saveButton { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun isDisplayedBadUser() {
+    every { mockUserViewModel.uiState } returns nonEmptyMockUiState
+    every { mockUserViewModel.getLoggedUserId() } returns "not_id1"
+    composeTestRule.setContent {
+      EditAccount(
+          modifier = Modifier,
+          userViewModel = mockUserViewModel,
+          navigationActions = mockNavActions)
+    }
+
+    ComposeScreen.onComposeScreen<EditAccount>(composeTestRule) {
+      topBar { assertIsDisplayed() }
+      backButton { assertIsDisplayed() }
+      bottomNavBar { assertIsDisplayed() }
+      notYourAccount { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun backButtonClick() {
+    every { mockUserViewModel.uiState } returns nonEmptyMockUiState
+    every { mockUserViewModel.getLoggedUserId() } returns "id1"
+    composeTestRule.setContent {
+      EditAccount(
+          modifier = Modifier,
+          userViewModel = mockUserViewModel,
+          navigationActions = mockNavActions)
+    }
+
+    ComposeScreen.onComposeScreen<EditAccount>(composeTestRule) { backButton { performClick() } }
+
+    verify(exactly = 1) { mockNavActions.goBack() }
+  }
+
+  @Test
+  fun saveButtonClick() {
+    every { mockUserViewModel.uiState } returns nonEmptyMockUiState
+    every { mockUserViewModel.getLoggedUserId() } returns "id1"
+    composeTestRule.setContent {
+      EditAccount(
+          modifier = Modifier,
+          userViewModel = mockUserViewModel,
+          navigationActions = mockNavActions)
+    }
+
+    ComposeScreen.onComposeScreen<EditAccount>(composeTestRule) { saveButton { performClick() } }
+
+    verify(exactly = 1) { mockUserViewModel.updateUser(any()) }
+    verify(exactly = 1) { mockNavActions.goBack() }
+  }
+}

--- a/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
@@ -72,6 +72,7 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     every { mockNavActions.goBack() } just Runs
   }
 
+  /** Test if the EditAccount screen is displayed correctly */
   @Test
   fun isDisplayedGoodUser() {
     every { mockUserViewModel.uiState } returns nonEmptyMockUiState
@@ -97,6 +98,7 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     }
   }
 
+  //* Test if the EditAccount screen doesn't allow editing other user profiles */
   @Test
   fun isDisplayedBadUser() {
     every { mockUserViewModel.uiState } returns nonEmptyMockUiState
@@ -116,6 +118,7 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     }
   }
 
+  /** Test if the 'back' button works correctly */
   @Test
   fun backButtonClick() {
     every { mockUserViewModel.uiState } returns nonEmptyMockUiState
@@ -132,6 +135,7 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     verify(exactly = 1) { mockNavActions.goBack() }
   }
 
+  /** Test if the 'save' button works correctly */
   @Test
   fun saveButtonClick() {
     every { mockUserViewModel.uiState } returns nonEmptyMockUiState

--- a/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
@@ -98,7 +98,7 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     }
   }
 
-  //* Test if the EditAccount screen doesn't allow editing other user profiles */
+  // * Test if the EditAccount screen doesn't allow editing other user profiles */
   @Test
   fun isDisplayedBadUser() {
     every { mockUserViewModel.uiState } returns nonEmptyMockUiState

--- a/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/editAccount/EditAccountTest.kt
@@ -12,9 +12,7 @@ import com.android.partagix.model.item.Item
 import com.android.partagix.model.user.User
 import com.android.partagix.screens.EditAccount
 import com.android.partagix.ui.navigation.NavigationActions
-import com.android.partagix.ui.navigation.Route
 import com.android.partagix.ui.screens.EditAccount
-import com.google.common.base.Verify.verify
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -36,10 +34,8 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
   @get:Rule val composeTestRule = createComposeRule()
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
-
   @RelaxedMockK lateinit var mockUserViewModel: UserViewModel
 
-  private lateinit var emptyMockUiState: MutableStateFlow<UserUIState>
   private lateinit var nonEmptyMockUiState: MutableStateFlow<UserUIState>
 
   val cat1 = Category("1", "Category 1")
@@ -62,13 +58,6 @@ class EditAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     every { mockUserViewModel.updateUser(any()) } just Runs
 
     mockNavActions = mockk<NavigationActions>()
-    every { mockNavActions.navigateTo(Route.HOME) } just Runs
-    every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
-    every { mockNavActions.navigateTo(Route.ACCOUNT) } just Runs
-    every { mockNavActions.navigateTo(Route.INVENTORY) } just Runs
-    every { mockNavActions.navigateTo(Route.LOAN) } just Runs
-    every { mockNavActions.navigateTo(Route.BOOT) } just Runs
-    every { mockNavActions.navigateTo(Route.VIEW_ITEM) } just Runs
     every { mockNavActions.goBack() } just Runs
   }
 

--- a/app/src/androidTest/java/com/android/partagix/screens/EditAccount.kt
+++ b/app/src/androidTest/java/com/android/partagix/screens/EditAccount.kt
@@ -1,0 +1,22 @@
+package com.android.partagix.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class EditAccount(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<EditAccount>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("editAccount") }) {
+
+  val topBar: KNode = child { hasTestTag("topBar") }
+  val backButton: KNode = child { hasTestTag("backButton") }
+  val bottomNavBar: KNode = child { hasTestTag("bottomNavBar") }
+  val notYourAccount: KNode = child { hasTestTag("notYourAccount") }
+  val mainContent: KNode = child { hasTestTag("mainContent") }
+  val userImage: KNode = child { hasTestTag("userImage") }
+  val username: KNode = child { hasTestTag("username") }
+  val usernameField: KNode = child { hasTestTag("usernameField") }
+  val addressField: KNode = child { hasTestTag("addressField") }
+  val actionButtons: KNode = child { hasTestTag("actionButtons") }
+  val saveButton: KNode = child { hasTestTag("saveButton") }
+}

--- a/app/src/androidTest/java/com/android/partagix/screens/ViewAccount.kt
+++ b/app/src/androidTest/java/com/android/partagix/screens/ViewAccount.kt
@@ -27,4 +27,5 @@ class ViewAccount(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val actionButtons: KNode = child { hasTestTag("actionButtons") } // row
   val inventoryButton: KNode = child { hasTestTag("inventoryButton") } // button
   val editButton: KNode = child { hasTestTag("editButton") } // button
+  val friendButton: KNode = child { hasTestTag("friendButton") } // button
 }

--- a/app/src/androidTest/java/com/android/partagix/screens/ViewAccount.kt
+++ b/app/src/androidTest/java/com/android/partagix/screens/ViewAccount.kt
@@ -34,6 +34,6 @@ class ViewAccount(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val actionButtons: KNode = child { hasTestTag("actionButtons") } // row
   val inventoryButton: KNode = child { hasTestTag("inventoryButton") } // button
   val inventoryButtonText: KNode = child { hasTestTag("inventoryButtonText") } // text
-  val friendButton: KNode = child { hasTestTag("friendButton") } // button
+  val editButton: KNode = child { hasTestTag("editButton") } // button
   val friendButtonText: KNode = child { hasTestTag("friendButtonText") } // text
 }

--- a/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
@@ -73,6 +73,8 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     every { mockNavActions.navigateTo(Route.LOAN) } just Runs
     every { mockNavActions.navigateTo(Route.BOOT) } just Runs
     every { mockNavActions.navigateTo(Route.VIEW_ITEM) } just Runs
+    every { mockNavActions.navigateTo(Route.EDIT_ACCOUNT) } just Runs
+    every { mockNavActions.goBack() } just Runs
     // todo right test ? or something for goBack instead ?
 
     /*    composeTestRule.setContent {
@@ -343,9 +345,9 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     }
   }
 
-  //    friendButton
+  //    editButton
   @Test
-  fun friendButtonIsDisplayed() = run {
+  fun editButtonIsDisplayed() = run {
     every { mockUserViewModel.uiState } returns emptyMockUiState
     composeTestRule.setContent {
       ViewAccount(
@@ -354,11 +356,11 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
           navigationActions = mockNavActions) // mockNavActions::navigateTo
     }
 
-    onComposeScreen<ViewAccount>(composeTestRule) { friendButton { assertIsDisplayed() } }
+    onComposeScreen<ViewAccount>(composeTestRule) { editButton { assertIsDisplayed() } }
   }
 
   @Test
-  fun friendButtonWorks() = run {
+  fun editButtonWorks() = run {
     every { mockUserViewModel.uiState } returns emptyMockUiState
     composeTestRule.setContent {
       ViewAccount(
@@ -368,9 +370,9 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     }
 
     onComposeScreen<ViewAccount>(composeTestRule) {
-      friendButton { assertIsDisplayed() }
-      friendButton { performClick() }
-      //        viewAccount { assertIsNotFocused() }
+      editButton { assertIsDisplayed() }
+      editButton { performClick() }
+      // viewAccount { assertIsNotFocused() }
     }
   }
 }

--- a/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
@@ -265,7 +265,7 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
 
   //    editButton
   @Test
-  fun editButtonIsDisplayed() = run {
+  fun editAndFriendButtonIsDisplayed() = run {
     every { mockUserViewModel.uiState } returns emptyMockUiState
     composeTestRule.setContent {
       ViewAccount(
@@ -274,11 +274,14 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
           navigationActions = mockNavActions)
     }
 
-    onComposeScreen<ViewAccount>(composeTestRule) { editButton { assertIsDisplayed() } }
+    onComposeScreen<ViewAccount>(composeTestRule) {
+      editButton { assertIsDisplayed() }
+      friendButton { assertIsDisplayed() }
+    }
   }
 
   @Test
-  fun editButtonWorks() = run {
+  fun editAndFriendButtonWorks() = run {
     every { mockUserViewModel.uiState } returns emptyMockUiState
     composeTestRule.setContent {
       ViewAccount(
@@ -290,6 +293,8 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     onComposeScreen<ViewAccount>(composeTestRule) {
       editButton { assertIsDisplayed() }
       editButton { performClick() }
+      friendButton { assertIsDisplayed() }
+      friendButton { performClick() }
     }
   }
 }

--- a/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/viewAccount/ViewAccountTest.kt
@@ -121,40 +121,42 @@ class ViewAccountTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
       inventoryButton { assertIsDisplayed() }
       inventoryButton { performClick() }
 
-  //    editButton
-  @Test
-  fun editAndFriendButtonIsDisplayed() = run {
-    every { mockUserViewModel.uiState } returns emptyMockUiState
-    composeTestRule.setContent {
-      ViewAccount(
-          modifier = Modifier,
-          userViewModel = mockUserViewModel,
-          navigationActions = mockNavActions)
-    }
+      //    editButton
+      @Test
+      fun editAndFriendButtonIsDisplayed() = run {
+        every { mockUserViewModel.uiState } returns emptyMockUiState
+        composeTestRule.setContent {
+          ViewAccount(
+              modifier = Modifier,
+              userViewModel = mockUserViewModel,
+              navigationActions = mockNavActions)
+        }
 
-    onComposeScreen<ViewAccount>(composeTestRule) {
-      editButton { assertIsDisplayed() }
-      friendButton { assertIsDisplayed() }
-    }
-  }
+        onComposeScreen<ViewAccount>(composeTestRule) {
+          editButton { assertIsDisplayed() }
+          friendButton { assertIsDisplayed() }
+        }
+      }
 
-  @Test
-  fun editAndFriendButtonWorks() = run {
-    every { mockUserViewModel.uiState } returns emptyMockUiState
-    composeTestRule.setContent {
-      ViewAccount(
-          modifier = Modifier,
-          userViewModel = mockUserViewModel,
-          navigationActions = mockNavActions)
-    }
+      @Test
+      fun editAndFriendButtonWorks() = run {
+        every { mockUserViewModel.uiState } returns emptyMockUiState
+        composeTestRule.setContent {
+          ViewAccount(
+              modifier = Modifier,
+              userViewModel = mockUserViewModel,
+              navigationActions = mockNavActions)
+        }
 
-    onComposeScreen<ViewAccount>(composeTestRule) {
-      editButton { assertIsDisplayed() }
-      editButton { performClick() }
-     
-      // friend button
-      friendButton { assertIsDisplayed() }
-      friendButton { performClick() }
+        onComposeScreen<ViewAccount>(composeTestRule) {
+          editButton { assertIsDisplayed() }
+          editButton { performClick() }
+
+          // friend button
+          friendButton { assertIsDisplayed() }
+          friendButton { performClick() }
+        }
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/partagix/model/Database.kt
+++ b/app/src/main/java/com/android/partagix/model/Database.kt
@@ -338,6 +338,11 @@ class Database(database: FirebaseFirestore = Firebase.firestore) {
     users.document(user.id).set(data)
   }
 
+    /** Update a user in the database
+     *
+     * @param user the user to update (with the new values)
+     * @param onSuccess the function to call when the user is updated
+     */
   fun updateUser(user: User, onSuccess: (User) -> Unit) {
     val data =
         hashMapOf(

--- a/app/src/main/java/com/android/partagix/model/Database.kt
+++ b/app/src/main/java/com/android/partagix/model/Database.kt
@@ -338,11 +338,12 @@ class Database(database: FirebaseFirestore = Firebase.firestore) {
     users.document(user.id).set(data)
   }
 
-    /** Update a user in the database
-     *
-     * @param user the user to update (with the new values)
-     * @param onSuccess the function to call when the user is updated
-     */
+  /**
+   * Update a user in the database
+   *
+   * @param user the user to update (with the new values)
+   * @param onSuccess the function to call when the user is updated
+   */
   fun updateUser(user: User, onSuccess: (User) -> Unit) {
     val data =
         hashMapOf(

--- a/app/src/main/java/com/android/partagix/model/Database.kt
+++ b/app/src/main/java/com/android/partagix/model/Database.kt
@@ -338,6 +338,18 @@ class Database(database: FirebaseFirestore = Firebase.firestore) {
     users.document(user.id).set(data)
   }
 
+  fun updateUser(user: User, onSuccess: (User) -> Unit) {
+    val data =
+        hashMapOf(
+            "id" to user.id,
+            "name" to user.name,
+            "addr" to user.address,
+            "rank" to user.rank,
+        )
+    users.document(user.id).set(data)
+    onSuccess(user)
+  }
+
   companion object {
     private const val TAG = "Database"
   }

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -47,9 +47,7 @@ class UserViewModel(
   private fun setUserToCurrent() {
     val userID = FirebaseAuth.getInstance().currentUser?.uid
 
-    if (userID == null) {
-      database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-    } else if (userID != "") {
+    if (userID != null) {
       database.getUser(userID) { updateUIState(it) }
     } else {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -70,10 +70,20 @@ class UserViewModel(
         )
   }
 
+  /**
+   * Update the user in the database and update the UI state when done
+   *
+   * @param user the user to update (with the new values)
+   */
   fun updateUser(user: User) {
     database.updateUser(user) { updateUIState(it) }
   }
 
+  /**
+   * Get the user id of the logged user
+   *
+   * @return the user id of the logged user
+   */
   fun getLoggedUserId(): String? {
     return FirebaseAuth.getInstance().currentUser?.uid
   }

--- a/app/src/main/java/com/android/partagix/model/UserViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/UserViewModel.kt
@@ -49,8 +49,7 @@ class UserViewModel(
 
     if (userID == null) {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
-    } else if (userID != "" &&
-        false) { // TODO: remove false when logged in users are in the database
+    } else if (userID != "") {
       database.getUser(userID) { updateUIState(it) }
     } else {
       database.getUser("XogPd4oF1nYc6Rag6zhh") { updateUIState(it) }
@@ -69,6 +68,14 @@ class UserViewModel(
         _uiState.value.copy(
             location = location,
         )
+  }
+
+  fun updateUser(user: User) {
+    database.updateUser(user) { updateUIState(it) }
+  }
+
+  fun getLoggedUserId(): String? {
+    return FirebaseAuth.getInstance().currentUser?.uid
   }
 
   companion object {

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -38,6 +38,7 @@ import com.android.partagix.model.user.User
 import com.android.partagix.ui.navigation.NavigationActions
 import com.android.partagix.ui.navigation.Route
 import com.android.partagix.ui.screens.BootScreen
+import com.android.partagix.ui.screens.EditAccount
 import com.android.partagix.ui.screens.HomeScreen
 import com.android.partagix.ui.screens.InventoryCreateOrEditItem
 import com.android.partagix.ui.screens.InventoryScreen
@@ -225,6 +226,13 @@ class App(
       ) {
         ViewAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
       }
+
+      composable(
+          Route.EDIT_ACCOUNT,
+      ) {
+        EditAccount(navigationActions = navigationActions, userViewModel = UserViewModel())
+      }
+
       composable(Route.VIEW_ITEM) {
         InventoryViewItem(navigationActions, itemViewModel, stampViewModel)
       }

--- a/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
@@ -18,6 +18,7 @@ object Route {
   const val VIEW_ITEM = "ViewItem"
   const val LOAN = "Loan"
   const val ACCOUNT = "Account"
+  const val EDIT_ACCOUNT = "EditAccount"
   const val CREATE_ITEM = "CreateItem"
   const val EDIT_ITEM = "EditItem"
   const val STAMP = "Stamp"

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -91,9 +91,7 @@ fun EditAccount(
             navigateToTopLevelDestination = navigationActions::navigateTo,
             modifier = modifier.testTag("bottomNavBar"))
       }) {
-        if (user.id !=
-            userViewModel
-                .getLoggedUserId()) {
+        if (user.id != userViewModel.getLoggedUserId()) {
           Text(
               text = "You can only edit your own account. (this shouldn't be seen)",
               modifier = Modifier.padding(it).testTag("notYourAccount"))

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -93,8 +93,7 @@ fun EditAccount(
       }) {
         if (user.id !=
             userViewModel
-                .getLoggedUserId()) { // && false should be remove when users will be synced with
-                                      // google auth
+                .getLoggedUserId()) {
           Text(
               text = "You can only edit your own account. (this shouldn't be seen)",
               modifier = Modifier.padding(it).testTag("notYourAccount"))

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -1,0 +1,153 @@
+package com.android.partagix.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.android.partagix.R
+import com.android.partagix.model.UserViewModel
+import com.android.partagix.ui.components.BottomNavigationBar
+import com.android.partagix.ui.navigation.NavigationActions
+import com.android.partagix.ui.navigation.Route
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditAccount(
+    modifier: Modifier = Modifier,
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+) {
+  val uiState = userViewModel.uiState.collectAsState()
+  val user = uiState.value.user
+
+  // Local state variables to hold temporary values for editable fields
+  var tempUsername by remember { mutableStateOf(user.name) }
+  var tempAddress by remember { mutableStateOf(user.address) }
+
+  // Set local state variables to user's current values
+  fun resetTempValues() {
+    tempUsername = user.name
+    tempAddress = user.address
+  }
+
+  // Set temporary values when the screen is opened
+  LaunchedEffect(key1 = user.id) { resetTempValues() }
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize().testTag("editAccount"),
+      topBar = {
+        TopAppBar(
+            modifier = Modifier.fillMaxWidth().testTag("topBar"),
+            title = { Text("My Account", modifier = Modifier.fillMaxWidth().testTag("title")) },
+            navigationIcon = {
+              IconButton(
+                  modifier = Modifier.testTag("backButton"),
+                  onClick = {
+                    resetTempValues()
+                    navigationActions.goBack()
+                  }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        modifier = Modifier.width(48.dp))
+                  }
+            })
+      },
+      bottomBar = {
+        BottomNavigationBar(
+            selectedDestination = Route.ACCOUNT,
+            navigateToTopLevelDestination = navigationActions::navigateTo,
+            modifier = modifier.testTag("bottomNavBar"))
+      }) {
+        if (user.id !=
+            userViewModel
+                .getLoggedUserId()) { // && false should be remove when users will be synced with
+                                      // google auth
+          Text(
+              text = "You can only edit your own account. (this shouldn't be seen)",
+              modifier = Modifier.padding(it).testTag("notYourAccount"))
+        } else {
+          Column(
+              modifier =
+                  Modifier.fillMaxHeight()
+                      .padding(it)
+                      .verticalScroll(rememberScrollState())
+                      .testTag("mainContent")) {
+                Image(
+                    painter =
+                        painterResource(
+                            id = R.drawable.ic_launcher_background) /*TODO: get profile picture*/,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxWidth().testTag("userImage"),
+                    alignment = Alignment.Center)
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth().testTag("username"),
+                    horizontalArrangement = Arrangement.Absolute.SpaceAround) {
+                      TextField(
+                          modifier = Modifier.testTag("usernameField"),
+                          value = tempUsername,
+                          onValueChange = { tempUsername = it },
+                          label = { Text("username") })
+                    }
+                Spacer(modifier = Modifier.height(16.dp))
+                TextField(
+                    value = tempAddress,
+                    onValueChange = { tempAddress = it },
+                    label = { Text("Location", modifier = Modifier.testTag("addressText")) },
+                    modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("addressField"),
+                    leadingIcon = {
+                      Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier)
+                    })
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons"),
+                    horizontalArrangement = Arrangement.Absolute.Center) {
+                      Spacer(modifier = Modifier.width(8.dp))
+                      Button(
+                          onClick = {
+                            // TODO save to db
+                            userViewModel.updateUser(
+                                user.copy(name = tempUsername, address = tempAddress))
+                            navigationActions.goBack()
+                          },
+                          modifier = Modifier.weight(1f).testTag("saveButton")) {
+                            Text("Save changes")
+                          }
+                    }
+              }
+        }
+      }
+}

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -76,7 +76,7 @@ fun EditAccount(
                   modifier = Modifier.testTag("backButton"),
                   onClick = {
                     resetTempValues() // Reset temp values to real values when back button is
-                                      // pressed
+                    // pressed
                     navigationActions.goBack()
                   }) {
                     Icon(

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -75,7 +75,8 @@ fun EditAccount(
               IconButton(
                   modifier = Modifier.testTag("backButton"),
                   onClick = {
-                    resetTempValues() // Reset temp values to real values when back button is pressed
+                    resetTempValues() // Reset temp values to real values when back button is
+                                      // pressed
                     navigationActions.goBack()
                   }) {
                     Icon(
@@ -91,7 +92,8 @@ fun EditAccount(
             navigateToTopLevelDestination = navigationActions::navigateTo,
             modifier = modifier.testTag("bottomNavBar"))
       }) {
-        if (user.id != userViewModel.getLoggedUserId()) { // Check if user is editing their own account
+        if (user.id !=
+            userViewModel.getLoggedUserId()) { // Check if user is editing their own account
           Text(
               text = "You can only edit your own account. (this shouldn't be seen)",
               modifier = Modifier.padding(it).testTag("notYourAccount"))
@@ -136,7 +138,10 @@ fun EditAccount(
                       Button(
                           onClick = {
                             userViewModel.updateUser(
-                                user.copy(name = tempUsername, address = tempAddress)) // Update user with new values in the database
+                                user.copy(
+                                    name = tempUsername,
+                                    address =
+                                        tempAddress)) // Update user with new values in the database
                             navigationActions.goBack()
                           },
                           modifier = Modifier.weight(1f).testTag("saveButton")) {

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -62,7 +62,7 @@ fun EditAccount(
     tempAddress = user.address
   }
 
-  // Set temporary values when the screen is opened
+  // Set temporary values to real values when the screen is opened
   LaunchedEffect(key1 = user.id) { resetTempValues() }
 
   Scaffold(
@@ -75,7 +75,7 @@ fun EditAccount(
               IconButton(
                   modifier = Modifier.testTag("backButton"),
                   onClick = {
-                    resetTempValues()
+                    resetTempValues() // Reset temp values to real values when back button is pressed
                     navigationActions.goBack()
                   }) {
                     Icon(
@@ -91,7 +91,7 @@ fun EditAccount(
             navigateToTopLevelDestination = navigationActions::navigateTo,
             modifier = modifier.testTag("bottomNavBar"))
       }) {
-        if (user.id != userViewModel.getLoggedUserId()) {
+        if (user.id != userViewModel.getLoggedUserId()) { // Check if user is editing their own account
           Text(
               text = "You can only edit your own account. (this shouldn't be seen)",
               modifier = Modifier.padding(it).testTag("notYourAccount"))
@@ -135,9 +135,8 @@ fun EditAccount(
                       Spacer(modifier = Modifier.width(8.dp))
                       Button(
                           onClick = {
-                            // TODO save to db
                             userViewModel.updateUser(
-                                user.copy(name = tempUsername, address = tempAddress))
+                                user.copy(name = tempUsername, address = tempAddress)) // Update user with new values in the database
                             navigationActions.goBack()
                           },
                           modifier = Modifier.weight(1f).testTag("saveButton")) {

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -80,6 +80,16 @@ fun ViewAccount(
                     .padding(it)
                     .verticalScroll(rememberScrollState())
                     .testTag("mainContent")) {
+              Row(
+                  modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("editButton"),
+                  horizontalArrangement = Arrangement.Absolute.Right) {
+                    Button(
+                        onClick = { navigationActions.navigateTo(Route.EDIT_ACCOUNT) },
+                        modifier = Modifier.testTag("editProfileButton")) {
+                          Text("Edit Profile")
+                        }
+                  }
+              Spacer(modifier = Modifier.height(8.dp))
               Image(
                   painter =
                       painterResource(
@@ -169,9 +179,9 @@ fun ViewAccount(
                         }
                     Spacer(modifier = Modifier.width(8.dp))
                     Button(
-                        onClick = { navigationActions.navigateTo(Route.EDIT_ACCOUNT) },
-                        modifier = Modifier.weight(1f).testTag("editButton")) {
-                          Text("Edit Profile")
+                        onClick = { /*TODO: friends*/},
+                        modifier = Modifier.weight(1f).testTag("friendButton")) {
+                          Text("Add Friends [not yet implemented]")
                         }
                   }
             }

--- a/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ViewAccount.kt
@@ -179,9 +179,9 @@ fun ViewAccount(
                         }
                     Spacer(modifier = Modifier.width(8.dp))
                     Button(
-                        onClick = { /*TODO: friends */},
-                        modifier = Modifier.weight(1f).testTag("friendButton")) {
-                          Text("Edit Profile [not yet implemented]")
+                        onClick = { navigationActions.navigateTo(Route.EDIT_ACCOUNT) },
+                        modifier = Modifier.weight(1f).testTag("editButton")) {
+                          Text("Edit Profile")
                         }
                   }
             }


### PR DESCRIPTION
I implemented the ability for the users to edit their own profile in a dedicated screen "EditAccount.kt".

 - The edited informations are only saved in the db when the "save" button is pressed while the "back" button discard them.
 - I added a security to not be able to edit other's profile (even if the edit button should only be displayed on user's own profile)