### PR TITLE
Cl/duplicate loans

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
@@ -148,8 +148,9 @@ class EndToEndCreateEdit {
     every { mockFirebaseUser.displayName } returns "name"
     every { mockFirebaseUser.email } returns "email"
 
-    every { mockManageViewModel.getInComingRequestCount(any()) } just Runs
-    every { mockManageViewModel.getOutGoingRequestCount(any()) } just Runs
+    // Useful when we will have fix the count
+    /*every { mockManageViewModel.getInComingRequestCount(any()) } just Runs
+    every { mockManageViewModel.getOutGoingRequestCount(any()) } just Runs*/
   }
 
   // Navigate from Home screen to Inventory screen

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryTest.kt
@@ -73,8 +73,9 @@ class InventoryTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
     every { mockNavActions.navigateTo(Route.HOME) } just Runs
     every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
 
-    every { mockManageLoanViewModel.getInComingRequestCount(any()) } just Runs
-    every { mockManageLoanViewModel.getOutGoingRequestCount(any()) } just Runs
+    // Useful when we will have fix the count for incoming/outgoing request
+    /* every { mockManageLoanViewModel.getInComingRequestCount(any()) } just Runs
+    every { mockManageLoanViewModel.getOutGoingRequestCount(any()) } just Runs*/
   }
 
   @Test

--- a/app/src/main/java/com/android/partagix/model/ManageLoanViewModel.kt
+++ b/app/src/main/java/com/android/partagix/model/ManageLoanViewModel.kt
@@ -34,15 +34,10 @@ class ManageLoanViewModel(
    * getInventory is a function that will update the uistate to have the items from your inventory
    * and to have the possible items you borrowed by checking your loans
    */
-  fun getLoanRequests(
-      latch: CountDownLatch = CountDownLatch(1),
-      isOutgoing: Boolean = false,
-      onSuccess: () -> Unit = {}
-  ) {
+  fun getLoanRequests(isOutgoing: Boolean = false, onSuccess: () -> Unit = {}) {
     val user = Authentication.getUser()
     if (user == null) {
       // TODO: Handle error
-      latch.countDown()
       return
     } else {
       database.getItemsWithImages { list ->
@@ -73,8 +68,7 @@ class ManageLoanViewModel(
                   expended.add(false)
                   loans.add(loan)
                 }
-            update(items, users, loans, emptyList())
-            latch.countDown()
+            update(items, users, loans, expended)
             onSuccess()
           }
         }
@@ -82,13 +76,15 @@ class ManageLoanViewModel(
     }
   }
 
-  fun getInComingRequestCount(onSuccess: (Int) -> Unit) {
+  // TODO: Fix so the count get the right number
+
+  /*  fun getInComingRequestCount(onSuccess: (Int) -> Unit) {
     getLoanRequests(isOutgoing = false, onSuccess = { onSuccess(uiState.value.loans.size) })
   }
 
   fun getOutGoingRequestCount(onSuccess: (Int) -> Unit) {
     getLoanRequests(isOutgoing = true, onSuccess = { onSuccess(uiState.value.loans.size) })
-  }
+  }*/
 
   fun update(
       items: List<Item>,
@@ -100,10 +96,6 @@ class ManageLoanViewModel(
         _uiState.value.copy(items = items, users = users, loans = loan, expanded = expanded)
   }
 
-  private fun updateItems(new: List<Item>) {
-    _uiState.value = _uiState.value.copy(items = new)
-  }
-
   /*private fun setupExpanded (size : Int) {
       val list = mutableListOf<Boolean>()
       for (i in 0 until size) {
@@ -111,17 +103,7 @@ class ManageLoanViewModel(
       }
       _uiState.value = _uiState.value.copy(expanded = list)
   }*/
-  private fun updateUsers(new: User) {
-    _uiState.value = _uiState.value.copy(users = _uiState.value.users.plus(new))
-  }
 
-  private fun updateLoans(new: List<Loan>) {
-    _uiState.value = _uiState.value.copy(loans = new)
-  }
-
-  private fun updateExpandedReset() {
-    _uiState.value = _uiState.value.copy(expanded = _uiState.value.expanded.plus(false))
-  }
   /*fun updateExpanded (index : Int) {
       val list = _uiState.value.expanded.toMutableList()
       list[index] = !list[index]

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -86,17 +86,10 @@ class App(
   private val inventoryViewModel = InventoryViewModel(db = db)
   private val manageViewModelLoan =
       ManageLoanViewModel(db = db, notificationManager = notificationManager)
-  private val manageViewModelStartLoan =
-      ManageLoanViewModel(db = db, notificationManager = notificationManager)
-  private val manageViewModelInventory =
-      ManageLoanViewModel(db = db, notificationManager = notificationManager)
-  private val manageViewModelHome =
+  private val manageViewModelIncoming =
       ManageLoanViewModel(db = db, notificationManager = notificationManager)
   private val manageViewModelOutgoing =
       ManageLoanViewModel(db = db, notificationManager = notificationManager)
-  private val manageViewModelIncoming =
-      ManageLoanViewModel(db = db, notificationManager = notificationManager)
-
   private val loanViewModel = LoanViewModel(db = db)
   private val borrowViewModel = BorrowViewModel(db = db, notificationManager = notificationManager)
   private val itemViewModel =
@@ -299,15 +292,14 @@ class App(
       composable(Route.BOOT) { BootScreen(authentication, navigationActions, modifier) }
       composable(Route.LOGIN) { LoginScreen(authentication, modifier) }
       composable(Route.HOME) {
-        println("--------------------Home")
         inventoryViewModel.getInventory()
-        manageViewModelHome.getLoanRequests(isOutgoing = false)
+        manageViewModelIncoming.getLoanRequests(isOutgoing = false)
         loanViewModel.getAvailableLoans()
         homeViewModel.updateUser()
 
         HomeScreen(
             homeViewModel = homeViewModel,
-            manageLoanViewModel = manageViewModelHome,
+            manageLoanViewModel = manageViewModelIncoming,
             navigationActions = navigationActions)
       }
       composable(Route.LOAN) {
@@ -333,12 +325,11 @@ class App(
         BorrowScreen(viewModel = borrowViewModel, navigationActions = navigationActions)
       }
       composable(Route.INVENTORY) {
-        println("--------------------Home")
         inventoryViewModel.getInventory()
         InventoryScreen(
             inventoryViewModel = inventoryViewModel,
             navigationActions = navigationActions,
-            manageLoanViewModel = manageViewModelInventory,
+            manageLoanViewModel = manageViewModelLoan,
             itemViewModel = itemViewModel)
       }
 
@@ -391,7 +382,6 @@ class App(
         InventoryCreateOrEditItem(itemViewModel, navigationActions, mode = "edit")
       }
       composable(Route.MANAGE_LOAN_REQUEST) {
-        println("--------------------Incoming requests")
         // Fetch the new loan requests first
         manageViewModelIncoming.getLoanRequests(isOutgoing = false)
         ManageLoanRequest(
@@ -406,7 +396,6 @@ class App(
             navigationActions = navigationActions)
       }
       composable(Route.MANAGE_OUTGOING_LOAN) {
-        println("--------------------Outgoing requests")
         manageViewModelOutgoing.getLoanRequests(isOutgoing = true)
         ManageOutgoingLoan(
             manageLoanViewModel = manageViewModelOutgoing,
@@ -426,7 +415,7 @@ class App(
         StartLoanScreen(
             startOrEndLoanViewModel = startOrEndLoanViewModel,
             navigationActions = navigationActions,
-            manageLoanViewModel = manageViewModelStartLoan,
+            manageLoanViewModel = manageViewModelLoan,
             itemViewModel = itemViewModel,
             modifier = modifier)
       }

--- a/app/src/main/java/com/android/partagix/ui/App.kt
+++ b/app/src/main/java/com/android/partagix/ui/App.kt
@@ -84,7 +84,17 @@ class App(
   lateinit var navigationActions: NavigationActions
 
   private val inventoryViewModel = InventoryViewModel(db = db)
-  private val manageViewModel =
+  private val manageViewModelLoan =
+      ManageLoanViewModel(db = db, notificationManager = notificationManager)
+  private val manageViewModelStartLoan =
+      ManageLoanViewModel(db = db, notificationManager = notificationManager)
+  private val manageViewModelInventory =
+      ManageLoanViewModel(db = db, notificationManager = notificationManager)
+  private val manageViewModelHome =
+      ManageLoanViewModel(db = db, notificationManager = notificationManager)
+  private val manageViewModelOutgoing =
+      ManageLoanViewModel(db = db, notificationManager = notificationManager)
+  private val manageViewModelIncoming =
       ManageLoanViewModel(db = db, notificationManager = notificationManager)
 
   private val loanViewModel = LoanViewModel(db = db)
@@ -289,14 +299,15 @@ class App(
       composable(Route.BOOT) { BootScreen(authentication, navigationActions, modifier) }
       composable(Route.LOGIN) { LoginScreen(authentication, modifier) }
       composable(Route.HOME) {
+        println("--------------------Home")
         inventoryViewModel.getInventory()
-        manageViewModel.getLoanRequests()
+        manageViewModelHome.getLoanRequests(isOutgoing = false)
         loanViewModel.getAvailableLoans()
         homeViewModel.updateUser()
 
         HomeScreen(
             homeViewModel = homeViewModel,
-            manageLoanViewModel = manageViewModel,
+            manageLoanViewModel = manageViewModelHome,
             navigationActions = navigationActions)
       }
       composable(Route.LOAN) {
@@ -312,7 +323,7 @@ class App(
               loanViewModel = loanViewModel,
               userViewModel = userViewModel,
               itemViewModel = itemViewModel,
-              manageLoanViewModel = manageViewModel,
+              manageLoanViewModel = manageViewModelLoan,
               modifier = modifier)
         } else {
           navigationActions.navigateTo(Route.HOME)
@@ -322,11 +333,12 @@ class App(
         BorrowScreen(viewModel = borrowViewModel, navigationActions = navigationActions)
       }
       composable(Route.INVENTORY) {
+        println("--------------------Home")
         inventoryViewModel.getInventory()
         InventoryScreen(
             inventoryViewModel = inventoryViewModel,
             navigationActions = navigationActions,
-            manageLoanViewModel = manageViewModel,
+            manageLoanViewModel = manageViewModelInventory,
             itemViewModel = itemViewModel)
       }
 
@@ -379,11 +391,11 @@ class App(
         InventoryCreateOrEditItem(itemViewModel, navigationActions, mode = "edit")
       }
       composable(Route.MANAGE_LOAN_REQUEST) {
+        println("--------------------Incoming requests")
         // Fetch the new loan requests first
-        manageViewModel.getLoanRequests()
-
+        manageViewModelIncoming.getLoanRequests(isOutgoing = false)
         ManageLoanRequest(
-            manageLoanViewModel = manageViewModel, navigationActions = navigationActions)
+            manageLoanViewModel = manageViewModelIncoming, navigationActions = navigationActions)
       }
       composable(Route.FINISHED_LOANS) {
         finishedLoansViewModel.getFinishedLoan()
@@ -394,8 +406,10 @@ class App(
             navigationActions = navigationActions)
       }
       composable(Route.MANAGE_OUTGOING_LOAN) {
+        println("--------------------Outgoing requests")
+        manageViewModelOutgoing.getLoanRequests(isOutgoing = true)
         ManageOutgoingLoan(
-            manageLoanViewModel = manageViewModel,
+            manageLoanViewModel = manageViewModelOutgoing,
             navigationActions = navigationActions,
         )
       }
@@ -412,7 +426,7 @@ class App(
         StartLoanScreen(
             startOrEndLoanViewModel = startOrEndLoanViewModel,
             navigationActions = navigationActions,
-            manageLoanViewModel = manageViewModel,
+            manageLoanViewModel = manageViewModelStartLoan,
             itemViewModel = itemViewModel,
             modifier = modifier)
       }

--- a/app/src/main/java/com/android/partagix/ui/components/ItemList.kt
+++ b/app/src/main/java/com/android/partagix/ui/components/ItemList.kt
@@ -42,7 +42,6 @@ fun ItemList(
     manageLoanViewModel: ManageLoanViewModel = ManageLoanViewModel(),
     stickyHeader: @Composable() (() -> Unit)? = null,
 ) {
-  println("------------------------in ItemList : ${itemList.size}")
   LazyColumn(modifier = modifier.fillMaxSize()) {
     if (stickyHeader != null) {
       stickyHeader { stickyHeader() }

--- a/app/src/main/java/com/android/partagix/ui/components/ItemList.kt
+++ b/app/src/main/java/com/android/partagix/ui/components/ItemList.kt
@@ -42,6 +42,7 @@ fun ItemList(
     manageLoanViewModel: ManageLoanViewModel = ManageLoanViewModel(),
     stickyHeader: @Composable() (() -> Unit)? = null,
 ) {
+  println("------------------------in ItemList : ${itemList.size}")
   LazyColumn(modifier = modifier.fillMaxSize()) {
     if (stickyHeader != null) {
       stickyHeader { stickyHeader() }

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -76,8 +76,8 @@ fun InventoryScreen(
   var incomingRequests by remember { mutableIntStateOf(0) }
   var outgoingRequests by remember { mutableIntStateOf(0) }
 
-  manageLoanViewModel.getInComingRequestCount { incomingRequests = it }
-  manageLoanViewModel.getOutGoingRequestCount { outgoingRequests = it }
+  /*manageLoanViewModel.getInComingRequestCount { incomingRequests = it }
+  manageLoanViewModel.getOutGoingRequestCount { outgoingRequests = it }*/
 
   Scaffold(
       modifier = modifier.testTag("inventoryScreen"),
@@ -159,11 +159,7 @@ fun InventoryScreen(
                   border =
                       BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
                   shape = MaterialTheme.shapes.small,
-                  onClick = {
-                    manageLoanViewModel.getLoanRequests(
-                        isOutgoing = false,
-                        onSuccess = { navigationActions.navigateTo(Route.MANAGE_LOAN_REQUEST) })
-                  }) {
+                  onClick = { navigationActions.navigateTo(Route.MANAGE_LOAN_REQUEST) }) {
                     Column(
                         modifier = modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.Center) {
@@ -185,11 +181,7 @@ fun InventoryScreen(
                   border =
                       BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
                   shape = MaterialTheme.shapes.small,
-                  onClick = {
-                    manageLoanViewModel.getLoanRequests(
-                        isOutgoing = true,
-                        onSuccess = { navigationActions.navigateTo(Route.MANAGE_OUTGOING_LOAN) })
-                  }) {
+                  onClick = { navigationActions.navigateTo(Route.MANAGE_OUTGOING_LOAN) }) {
                     Column(
                         modifier = modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.Center) {

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -33,8 +33,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -73,8 +71,10 @@ fun InventoryScreen(
     modifier: Modifier = Modifier,
 ) {
   val uiState by inventoryViewModel.uiState.collectAsStateWithLifecycle()
-  var incomingRequests by remember { mutableIntStateOf(0) }
-  var outgoingRequests by remember { mutableIntStateOf(0) }
+
+  // Useful when we will have fix the count
+  /*var incomingRequests by remember { mutableIntStateOf(0) }
+  var outgoingRequests by remember { mutableIntStateOf(0) }*/
 
   /*manageLoanViewModel.getInComingRequestCount { incomingRequests = it }
   manageLoanViewModel.getOutGoingRequestCount { outgoingRequests = it }*/
@@ -169,7 +169,9 @@ fun InventoryScreen(
                               contentDescription = "incoming requests",
                               modifier = Modifier.align(Alignment.CenterHorizontally))
                           Text(
-                              text = "Incoming Requests ($incomingRequests)",
+                              text = "Incoming Requests " /*($incomingRequests)*/, // TODO: put back
+                              // when we fix the
+                              // count
                               color = MaterialTheme.colorScheme.onSecondaryContainer,
                               style = TextStyle(fontSize = 10.sp),
                               modifier = Modifier.align(Alignment.CenterHorizontally))
@@ -191,7 +193,9 @@ fun InventoryScreen(
                               contentDescription = "outgoing requests",
                               modifier = Modifier.align(Alignment.CenterHorizontally))
                           Text(
-                              text = "Outgoing Requests ($outgoingRequests)",
+                              text = "Outgoing Requests" /*($outgoingRequests)*/, // TODO: put back
+                              // when we fix the
+                              // count
                               color = MaterialTheme.colorScheme.onSecondaryContainer,
                               style = TextStyle(fontSize = 10.sp),
                               modifier = Modifier.align(Alignment.CenterHorizontally))


### PR DESCRIPTION
I fixed the problem where a loan was displayed multiple times on the home, incoming, and outgoing screens.
For now, I also commented on the things related to the number of incoming/outgoing as it's not functional now and is a bigger fix than we think, to have a clean version for the M3 (and it should be the purpose of another PR)
I used multiple manage loan view model, because we had the old loans being displayed before the ones we wanted were being fetched/displayed.
