### PR TITLE
MB/308-further-item-UI-fixes

### DIFF
--- a/app/src/androidTest/java/com/android/partagix/ItemViewModelTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/ItemViewModelTests.kt
@@ -62,7 +62,7 @@ class ItemViewModelTests {
           Category("0", "Category 1"),
           "modify",
           "modified",
-          Visibility.FRIENDS,
+          Visibility.PUBLIC,
           3,
           Location(""))
   val itemNoID =

--- a/app/src/androidTest/java/com/android/partagix/LoanViewModelTests.kt
+++ b/app/src/androidTest/java/com/android/partagix/LoanViewModelTests.kt
@@ -86,7 +86,7 @@ class LoanViewModelTests {
           Category("4", "Category 4"),
           "test4",
           "test4",
-          Visibility.FRIENDS,
+          Visibility.PUBLIC,
           1,
           Location(""),
           "user4",

--- a/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
@@ -126,7 +126,6 @@ class BorrowTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
     mockViewModel.startBorrow(item, user)
 
     onComposeScreen<BorrowScreen>(composeTestRule) {
-      //      description { performTextInput("test description") }
       startDateButton { performClick() }
       startDateOk { performClick() }
       endDateButton { performClick() }

--- a/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
@@ -126,6 +126,7 @@ class BorrowTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
     mockViewModel.startBorrow(item, user)
 
     onComposeScreen<BorrowScreen>(composeTestRule) {
+      description { performTextInput("test description") }
       startDateButton { performClick() }
       startDateOk { performClick() }
       endDateButton { performClick() }

--- a/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
@@ -126,7 +126,7 @@ class BorrowTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
     mockViewModel.startBorrow(item, user)
 
     onComposeScreen<BorrowScreen>(composeTestRule) {
-      description { performTextInput("test description") }
+      //      description { performTextInput("test description") }
       startDateButton { performClick() }
       startDateOk { performClick() }
       endDateButton { performClick() }

--- a/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/borrow/BorrowTest.kt
@@ -65,6 +65,7 @@ class BorrowTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
 
     mockNavActions = mockk<NavigationActions>()
     every { mockNavActions.navigateTo(Route.HOME) } just Runs
+    every { mockNavActions.navigateTo(Route.LOAN) } just Runs
     every { mockNavActions.navigateTo(Route.LOGIN) } just Runs
     every { mockNavActions.goBack() } just Runs
   }
@@ -126,7 +127,6 @@ class BorrowTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
     mockViewModel.startBorrow(item, user)
 
     onComposeScreen<BorrowScreen>(composeTestRule) {
-      description { performTextInput("test description") }
       startDateButton { performClick() }
       startDateOk { performClick() }
       endDateButton { performClick() }

--- a/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
@@ -204,7 +204,7 @@ class EndToEndCreateEdit {
 
     composeTestRule
         .onNodeWithText(
-            "There is no items in your inventory, click on the + button to add your first item")
+            "You have no items in your inventory, click on the + button to add your first item")
         .assertIsDisplayed()
     composeTestRule.onNodeWithTag("inventoryScreenFab").performClick()
 

--- a/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/EndToEndCreateEdit.kt
@@ -86,7 +86,7 @@ class EndToEndCreateEdit {
   private lateinit var mockHomeUiState: MutableStateFlow<HomeUIState>
 
   val cat1 = Category("1", CategoryItems[1])
-  val vis1 = Visibility.FRIENDS
+  val vis1 = Visibility.PUBLIC
   val loc1 = Location("")
   val loc2 = com.android.partagix.model.location.Location(12.0, 12.0, "Lausanne")
   val loc3 = com.android.partagix.model.location.Location(13.0, 13.0, "Paris")
@@ -237,7 +237,7 @@ class EndToEndCreateEdit {
             Category("", CategoryItems[1]),
             "Object 1",
             "Description 1",
-            Visibility.FRIENDS,
+            Visibility.PUBLIC,
             2,
             androidLocation3,
             imageId = File("default-image.jpg"))
@@ -270,7 +270,7 @@ class EndToEndCreateEdit {
     composeTestRule.onNodeWithTag("description").performTextInput("Description 1")
     composeTestRule.onNodeWithTag("quantity").performTextReplacement("2")
     composeTestRule.onNodeWithTag("visibility").performClick()
-    composeTestRule.onNodeWithText("Friends only").performClick()
+    composeTestRule.onNodeWithText("Everyone").performClick()
 
     composeTestRule.onNodeWithTag("addressField").performScrollTo()
     composeTestRule.onNodeWithTag("addressField").performClick()
@@ -330,7 +330,7 @@ class EndToEndCreateEdit {
     composeTestRule.onNodeWithText("Object 1").assertIsDisplayed()
     composeTestRule.onNodeWithText("Description 1").assertIsDisplayed()
     composeTestRule.onNodeWithText("2").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Friends only").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Everyone").assertIsDisplayed()
     composeTestRule.onNodeWithText(CategoryItems[1]).assertIsDisplayed()
     composeTestRule.onNodeWithText("Edit").performScrollTo()
     composeTestRule.onNodeWithText("Edit").performClick()
@@ -387,7 +387,7 @@ class EndToEndCreateEdit {
     composeTestRule.onNodeWithText("Object 1 edited").assertIsDisplayed()
     composeTestRule.onNodeWithText("Description 1 edited").assertIsDisplayed()
     composeTestRule.onNodeWithText("3").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Friends only").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Everyone").assertIsDisplayed()
     composeTestRule.onNodeWithText(CategoryItems[1]).assertIsDisplayed()
     composeTestRule.onNodeWithTag("navigationIcon").performClick()
 

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryCreateOrEditTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryCreateOrEditTest.kt
@@ -124,10 +124,7 @@ class InventoryCreateOrEditTest :
         assertTextContains("Object name")
       }
 
-      idUser {
-        assertIsDisplayed()
-        assertTextContains("Owner")
-      }
+      idUser { assertIsDisplayed() }
 
       description {
         assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/partagix/inventory/InventoryTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/inventory/InventoryTest.kt
@@ -101,7 +101,7 @@ class InventoryTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
       noItemText {
         assertIsDisplayed()
         assertTextEquals(
-            "There is no items in your inventory, click on the + button to add your first item")
+            "You have no items in your inventory, click on the + button to add your first item")
       }
       bottomNavBar { assertIsDisplayed() }
       bottomNavBarItemInventory { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/android/partagix/loan/ManageLoanTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/loan/ManageLoanTest.kt
@@ -102,7 +102,7 @@ class ManageLoanTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
     ComposeScreen.onComposeScreen<ManageLoanScreen>(composeTestRule) {
       noItemText {
         assertIsDisplayed()
-        assertTextEquals("There is no loan request.")
+        assertTextEquals("You have no loan request.")
       }
     }
   }

--- a/app/src/androidTest/java/com/android/partagix/loan/ManageOutgoingLoanTest.kt
+++ b/app/src/androidTest/java/com/android/partagix/loan/ManageOutgoingLoanTest.kt
@@ -103,7 +103,7 @@ class ManageOutgoingLoanTest : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
     ComposeScreen.onComposeScreen<ManageOutgoingLoanScreen>(composeTestRule) {
       noItemText {
         assertIsDisplayed()
-        assertTextEquals("There is no outgoing loan request.")
+        assertTextEquals("You have no outgoing loan request.")
       }
     }
   }

--- a/app/src/main/java/com/android/partagix/model/visibility/Visibility.kt
+++ b/app/src/main/java/com/android/partagix/model/visibility/Visibility.kt
@@ -2,8 +2,8 @@ package com.android.partagix.model.visibility
 
 enum class Visibility(val visibilityLabel: String) {
   PUBLIC("Everyone"), // ordinal = 0
-  FRIENDS("Friends only"), // ordinal = 1
-  PRIVATE("No one") // ordinal = 2
+  PRIVATE("No one") // ordinal = 1
+  //  FRIENDS("Friends only"), // ordinal = 2
 }
 
 /**

--- a/app/src/main/java/com/android/partagix/ui/components/TopSearchBar.kt
+++ b/app/src/main/java/com/android/partagix/ui/components/TopSearchBar.kt
@@ -57,7 +57,7 @@ fun TopSearchBar(filter: (String) -> Unit, modifier: Modifier = Modifier, query:
       },
       active = false,
       onActiveChange = { active = it },
-      modifier = modifier.fillMaxWidth().padding(20.dp),
+      modifier = modifier.fillMaxWidth().padding(horizontal = 8.dp),
       placeholder = { Text("Search an Item") },
       leadingIcon = {
         if (!active) {

--- a/app/src/main/java/com/android/partagix/ui/components/locationPicker/LocationPicker.kt
+++ b/app/src/main/java/com/android/partagix/ui/components/locationPicker/LocationPicker.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -34,7 +35,7 @@ fun LocationPicker(
       onValueChange = { onTextChanged(it) },
       label = { Text(text = "Location", color = MaterialTheme.colorScheme.onBackground) },
       modifier =
-          Modifier.fillMaxWidth() /*.padding(8.dp)*/.testTag("addressField").onFocusChanged {
+          Modifier.fillMaxWidth().testTag("addressField").onFocusChanged {
             focused = it.isFocused
             if (!focused) {
               onTextChanged(loc?.locationName ?: location)
@@ -54,7 +55,8 @@ fun LocationPicker(
       },
       leadingIcon = {
         Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier)
-      })
+      },
+      colors = OutlinedTextFieldDefaults.colors())
 
   LaunchedEffect(
       key1 = location,

--- a/app/src/main/java/com/android/partagix/ui/components/locationPicker/LocationPicker.kt
+++ b/app/src/main/java/com/android/partagix/ui/components/locationPicker/LocationPicker.kt
@@ -1,7 +1,6 @@
 package com.android.partagix.ui.components.locationPicker
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
@@ -18,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
 import com.android.partagix.model.location.Location
 import kotlinx.coroutines.delay
 
@@ -36,7 +34,7 @@ fun LocationPicker(
       onValueChange = { onTextChanged(it) },
       label = { Text(text = "Location", color = MaterialTheme.colorScheme.onBackground) },
       modifier =
-          Modifier.fillMaxWidth().padding(8.dp).testTag("addressField").onFocusChanged {
+          Modifier.fillMaxWidth() /*.padding(8.dp)*/.testTag("addressField").onFocusChanged {
             focused = it.isFocused
             if (!focused) {
               onTextChanged(loc?.locationName ?: location)

--- a/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
@@ -18,7 +18,7 @@ object Route {
   const val QR_SCAN = "QrScan"
   const val VIEW_ITEM = "ViewItem"
   const val VIEW_OTHERS_ITEM = "ViewOthersItem"
-  const val LOAN = "Loan"
+  const val LOAN = "Borrow"
   const val BORROW = "Borrow"
   const val ACCOUNT = "Account"
   const val OTHER_ACCOUNT = "OtherAccount"

--- a/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/partagix/ui/navigation/NavigationActions.kt
@@ -18,7 +18,7 @@ object Route {
   const val QR_SCAN = "QrScan"
   const val VIEW_ITEM = "ViewItem"
   const val VIEW_OTHERS_ITEM = "ViewOthersItem"
-  const val LOAN = "Borrow"
+  const val LOAN = "Loan"
   const val BORROW = "Borrow"
   const val ACCOUNT = "Account"
   const val OTHER_ACCOUNT = "OtherAccount"

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.partagix.R
 import com.android.partagix.model.BorrowViewModel
 import com.android.partagix.ui.components.BottomNavigationBar
+import com.android.partagix.ui.components.LabeledText
 import com.android.partagix.ui.navigation.NavigationActions
 import com.android.partagix.ui.navigation.Route
 import java.text.DateFormat
@@ -139,19 +140,17 @@ fun BorrowScreen(
                   Spacer(modifier = modifier.width(8.dp))
 
                   Column {
-                    OutlinedTextField(
-                        value = loanItemName,
-                        onValueChange = {},
-                        label = { Text("Item name") },
-                        modifier = modifier.testTag("itemName").fillMaxWidth(),
-                        maxLines = 1, // Ensure only one line is displayed
-                        readOnly = true)
-                    OutlinedTextField(
-                        value = loanItemOwnerName,
-                        onValueChange = {},
-                        label = { Text("Owner") },
-                        modifier = modifier.testTag("itemOwner").fillMaxWidth(),
-                        readOnly = true)
+                    LabeledText(
+                        label = "Object Name",
+                        text = loanItemName,
+                        modifier = modifier.fillMaxWidth().fillMaxHeight(0.5f).testTag("itemName"))
+
+                    LabeledText(
+                        label = "Owner",
+                        text = loanItemOwnerName,
+                        modifier = modifier.fillMaxWidth().testTag("itemOwner")
+                        //                        .clickable { /* todo */ }
+                        )
                   }
                 }
               }
@@ -163,6 +162,11 @@ fun BorrowScreen(
                     modifier = modifier.fillMaxWidth().testTag("description"),
                     minLines = 5,
                     readOnly = true)
+
+                /*                LabeledText(
+                modifier = modifier.fillMaxWidth().testTag("description"),
+                label = "Description",
+                text = loanDescription)*/
 
                 Spacer(modifier = modifier.height(8.dp))
 

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -17,19 +17,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -91,9 +87,7 @@ fun BorrowScreen(
 
         val loanItemName by remember { mutableStateOf(item.name) }
         val loanItemOwnerName by remember { mutableStateOf(user.name) }
-        var loanDescription by remember {
-          mutableStateOf("")
-        } // TODO: edit Loan type to include description
+        val loanDescription by remember { mutableStateOf(item.description) }
         val loanLocation by remember { mutableStateOf(item.location) }
         val loanQuantity by remember { mutableStateOf(item.quantity) }
 
@@ -156,13 +150,10 @@ fun BorrowScreen(
                 }
               }
               Column(modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
-                TextField(
-                    value = loanDescription,
-                    onValueChange = { loanDescription = it },
-                    label = { Text("Description") },
+                LabeledText(
                     modifier = modifier.fillMaxWidth().testTag("description"),
-                    minLines = 5,
-                    readOnly = true)
+                    label = "Description",
+                    text = loanDescription)
 
                 Spacer(modifier = modifier.height(8.dp))
 
@@ -263,22 +254,14 @@ fun BorrowScreen(
                 }
                 Spacer(modifier = modifier.height(8.dp))
 
-                OutlinedTextField(
-                    value = loanQuantity.toString(),
-                    onValueChange = {},
-                    label = { Text("Quantity") },
+                LabeledText(
                     modifier = modifier.fillMaxWidth(),
-                    readOnly = false)
+                    label = "Quantity",
+                    text = loanQuantity.toString())
               }
 
               Button(
                   modifier = modifier.fillMaxWidth().testTag("saveButton").padding(10.dp),
-                  colors =
-                      ButtonColors(
-                          containerColor = MaterialTheme.colorScheme.onPrimary,
-                          contentColor = MaterialTheme.colorScheme.onBackground,
-                          disabledContentColor = MaterialTheme.colorScheme.onBackground,
-                          disabledContainerColor = Color.Gray),
                   onClick = {
                     viewModel.createLoan()
                     navigationActions.navigateTo(Route.LOAN)

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -287,7 +287,7 @@ fun BorrowScreen(
                     viewModel.createLoan()
                     navigationActions.navigateTo(Route.LOAN)
                   },
-                  content = { Text(text = "Make request reservation") })
+                  content = { Text(text = "Request reservation") })
             }
       }
 }

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -90,8 +91,7 @@ fun BorrowScreen(
 
         val loanItemName by remember { mutableStateOf(item.name) }
         val loanItemOwnerName by remember { mutableStateOf(user.name) }
-        var loanDescription by remember {
-          mutableStateOf("")
+        var loanDescription by remember { mutableStateOf("")
         } // TODO: edit Loan type to include description
         val loanLocation by remember { mutableStateOf(item.location) }
         val loanQuantity by remember { mutableStateOf(item.quantity) }
@@ -155,18 +155,13 @@ fun BorrowScreen(
                 }
               }
               Column(modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
-                OutlinedTextField(
+                TextField(
                     value = loanDescription,
                     onValueChange = { loanDescription = it },
                     label = { Text("Description") },
                     modifier = modifier.fillMaxWidth().testTag("description"),
                     minLines = 5,
                     readOnly = true)
-
-                /*                LabeledText(
-                modifier = modifier.fillMaxWidth().testTag("description"),
-                label = "Description",
-                text = loanDescription)*/
 
                 Spacer(modifier = modifier.height(8.dp))
 

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -157,12 +157,10 @@ fun BorrowScreen(
 
                 Spacer(modifier = modifier.height(8.dp))
 
-                OutlinedTextField(
-                    value = loanLocation.toString(),
-                    onValueChange = {},
-                    label = { Text("Location") },
+                LabeledText(
                     modifier = modifier.fillMaxWidth().testTag("location"),
-                    readOnly = true)
+                    label = "Location",
+                    text = loanLocation.toString())
 
                 Spacer(modifier = modifier.height(8.dp))
 

--- a/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/BorrowScreen.kt
@@ -91,7 +91,8 @@ fun BorrowScreen(
 
         val loanItemName by remember { mutableStateOf(item.name) }
         val loanItemOwnerName by remember { mutableStateOf(user.name) }
-        var loanDescription by remember { mutableStateOf("")
+        var loanDescription by remember {
+          mutableStateOf("")
         } // TODO: edit Loan type to include description
         val loanLocation by remember { mutableStateOf(item.location) }
         val loanQuantity by remember { mutableStateOf(item.quantity) }

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -145,7 +146,8 @@ fun EditAccount(
                     modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("usernameField"),
                     value = tempUsername,
                     onValueChange = { tempUsername = it },
-                    label = { Text("username") })
+                    label = { Text("username") },
+                    colors = OutlinedTextFieldDefaults.colors())
 
                 Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/EditAccount.kt
@@ -149,17 +149,18 @@ fun EditAccount(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                LocationPicker(
-                    location = tempAddress,
-                    loc = loc.value,
-                    onTextChanged = { tempAddress = it },
-                    onLocationLookup = { locationViewModel.getLocation(it, loc) })
+                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+                  LocationPicker(
+                      location = tempAddress,
+                      loc = loc.value,
+                      onTextChanged = { tempAddress = it },
+                      onLocationLookup = { locationViewModel.getLocation(it, loc) })
+                }
 
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(8.dp, 0.dp).testTag("actionButtons"),
                     horizontalArrangement = Arrangement.Absolute.Center) {
-                      Spacer(modifier = Modifier.width(8.dp))
                       Button(
                           onClick = {
                             userViewModel.updateUser(

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -46,6 +47,7 @@ import com.android.partagix.model.visibility.getVisibility
 import com.android.partagix.ui.components.BottomNavigationBar
 import com.android.partagix.ui.components.CategoryItems
 import com.android.partagix.ui.components.DropDown
+import com.android.partagix.ui.components.LabeledText
 import com.android.partagix.ui.components.MainImagePicker
 import com.android.partagix.ui.components.VisibilityItems
 import com.android.partagix.ui.components.locationPicker.LocationPicker
@@ -135,7 +137,10 @@ fun InventoryCreateOrEditItem(
                           modifier
                               .fillMaxHeight()
                               .fillMaxWidth(.4f)
-                              .border(1.dp, MaterialTheme.colorScheme.onBackground)
+                              .border(
+                                  1.dp,
+                                  MaterialTheme.colorScheme.outline,
+                                  shape = RoundedCornerShape(4.dp))
                               .testTag("image")) {
                         val image =
                             File(uiImage.toString().ifEmpty { "res/drawable/default_image.jpg" })
@@ -175,12 +180,8 @@ fun InventoryCreateOrEditItem(
                         maxLines = 1, // Ensure only one line is displayed
                         readOnly = false)
 
-                    OutlinedTextField(
-                        value = uiState.user.name,
-                        onValueChange = {},
-                        label = { Text("Owner") },
-                        modifier = modifier.testTag("idUser").fillMaxWidth(),
-                        readOnly = true)
+                    LabeledText(
+                        modifier.testTag("idUser").fillMaxWidth(), "Owner", uiState.user.name)
                   }
                 }
               }

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -35,7 +34,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -253,12 +251,6 @@ fun InventoryCreateOrEditItem(
                       navigationActions.goBack()
                     },
                     enabled = uiName.isNotBlank(),
-                    colors =
-                        ButtonColors(
-                            containerColor = MaterialTheme.colorScheme.onPrimary,
-                            contentColor = MaterialTheme.colorScheme.onBackground,
-                            disabledContentColor = MaterialTheme.colorScheme.onBackground,
-                            disabledContainerColor = Color.Gray),
                     content = {
                       if (mode == "edit") {
                         Text("Save")

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryCreateOrEditItemScreen.kt
@@ -211,7 +211,7 @@ fun InventoryCreateOrEditItem(
                   }
                 }
 
-                Spacer(modifier = modifier.height(8.dp))
+                //                Spacer(modifier = modifier.height(8.dp))
 
                 OutlinedTextField(
                     value = if (uiQuantity == 0L) "" else uiQuantity.toString(),

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -131,7 +131,7 @@ fun InventoryScreen(
         } else {
           Column(modifier = modifier.padding(innerPadding).fillMaxSize()) {
             Row(
-                modifier = modifier.fillMaxWidth().padding(10.dp, 0.dp),
+                modifier = modifier.fillMaxWidth().padding(10.dp, 0.dp).padding(top = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween) {
                   Text(
                       text = "Loan requests",

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ButtonDefaults.buttonColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -229,6 +230,10 @@ fun InventoryScreen(
                       Modifier.padding(horizontal = 10.dp)
                           .fillMaxHeight(0.4f)
                           .testTag("inventoryScreenBorrowedItemList"))
+
+              HorizontalDivider(
+                  color = MaterialTheme.colorScheme.outlineVariant,
+                  modifier = Modifier.height(0.5.dp).fillMaxWidth().padding(horizontal = 10.dp))
 
               Spacer(modifier = Modifier.height(8.dp))
               ItemListColumn(

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -123,7 +123,7 @@ fun InventoryScreen(
                       .testTag("inventoryScreenNoItemBox")) {
                 Text(
                     text =
-                        "There is no items in your inventory, click on the + button to add your first item",
+                        "You have no items in your inventory, click on the + button to add your first item",
                     textAlign = TextAlign.Center,
                     modifier =
                         modifier.align(Alignment.Center).testTag("inventoryScreenNoItemText"))

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryScreen.kt
@@ -134,7 +134,7 @@ fun InventoryScreen(
                 modifier = modifier.fillMaxWidth().padding(10.dp, 0.dp).padding(top = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween) {
                   Text(
-                      text = "Loan requests",
+                      text = "Loan Requests",
                       style =
                           TextStyle(
                               fontSize = 18.sp,
@@ -210,7 +210,7 @@ fun InventoryScreen(
                   list = uiState.borrowedItems,
                   users = uiState.usersBor,
                   loan = uiState.loanBor,
-                  title = "Borrowed items",
+                  title = "Borrowed",
                   corner = uiState.borrowedItems.size.toString(),
                   onItemClick = {
                     itemViewModel.updateUiItem(it)
@@ -235,7 +235,7 @@ fun InventoryScreen(
                   list = uiState.items,
                   users = uiState.users,
                   loan = uiState.loan,
-                  title = "Inventory item",
+                  title = "My Inventory",
                   corner = uiState.items.size.toString(),
                   onItemClick = {
                     itemViewModel.updateUiItem(it)

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -185,7 +185,6 @@ fun InventoryViewItemScreen(
                         modifier = Modifier.fillMaxWidth().testTag("editItemButton"))
                   } else {
                     Button(
-                        enabled = actualUser != user.id && actualUser != "" && user.id != "",
                         onClick = {
                           borrowViewModel.startBorrow(item, user)
                           navigationActions.navigateTo(Route.BORROW)

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,12 +16,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -35,7 +34,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -113,11 +111,14 @@ fun InventoryViewItemScreen(
                         contentDescription = "fds",
                         contentScale = ContentScale.FillWidth,
                         modifier =
-                            Modifier.fillMaxWidth(0.3f)
-                                .border(1.dp, MaterialTheme.colorScheme.onBackground),
+                            Modifier.fillMaxWidth(0.4f)
+                                .border(
+                                    1.dp,
+                                    MaterialTheme.colorScheme.outlineVariant,
+                                    shape = RoundedCornerShape(4.dp)),
                         alignment = Alignment.Center)
                   }
-                  Spacer(modifier = Modifier.width(8.dp))
+                  Spacer(modifier = Modifier.width(4.dp))
 
                   Column {
                     LabeledText(
@@ -142,110 +143,56 @@ fun InventoryViewItemScreen(
               Column(Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
                 LabeledText(label = "Description", text = item.description)
 
-                Spacer(modifier = Modifier.height(8.dp))
                 if (!viewOthersItem) {
                   LabeledText(label = "Category", text = item.category.name)
 
-                  Spacer(modifier = Modifier.height(8.dp))
-
                   LabeledText(label = "Visibility", text = item.visibility.visibilityLabel)
-
-                  Spacer(modifier = Modifier.height(8.dp))
                 }
 
                 LabeledText(label = "Quantity", text = item.quantity.toString())
-
-                Spacer(modifier = Modifier.height(8.dp))
 
                 LabeledText(
                     label = "Where",
                     text = item.location.extras?.getString("display_name", "Unknown") ?: "Unknown")
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Row(modifier = Modifier.fillMaxWidth()) {
+                  LabeledText(
+                      modifier = Modifier.fillMaxWidth(0.8f),
+                      label = "Availability",
+                      text =
+                          "Now available") /* todo : branch with the availability like in itemUi */
 
-                Box(modifier = Modifier.padding(8.dp)) {
-                  Column {
-                    Text(
-                        text = "Availability",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                          Text(
-                              text = "available", /*TODO: get item disponibility*/
-                              style = MaterialTheme.typography.bodyMedium,
-                              color = MaterialTheme.colorScheme.onBackground,
-                              modifier = Modifier.padding(6.dp, 0.dp, 0.dp, 0.dp),
-                          )
-
-                          IconButton(
-                              onClick = { /*TODO: see calendar with disponibilities*/},
-                              content = {
-                                Icon(Icons.Default.DateRange, contentDescription = null)
-                              })
-                        }
-                  }
+                  IconButton(
+                      onClick = { /*TODO: see calendar with disponibilities*/},
+                      content = { Icon(Icons.Default.DateRange, contentDescription = null) })
                 }
-                Spacer(modifier = Modifier.height(8.dp))
 
                 Row(modifier = Modifier.fillMaxWidth()) {
                   Button(
                       onClick = { navigationActions.navigateTo("${Route.STAMP}/${item.id}") },
-                      colors =
-                          ButtonColors(
-                              containerColor = MaterialTheme.colorScheme.onPrimary,
-                              contentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContainerColor = Color.Gray),
-                      content = {
-                        Text(
-                            "Download QR code",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                      },
+                      content = { Text("Download QR code") },
                       modifier = Modifier.fillMaxWidth(0.5f))
 
                   Spacer(modifier = Modifier.width(8.dp))
-                  Button(
-                      enabled = actualUser != user.id && actualUser != "" && user.id != "",
-                      onClick = {
-                        borrowViewModel.startBorrow(item, user)
-                        navigationActions.navigateTo(Route.BORROW)
-                      },
-                      colors =
-                          ButtonColors(
-                              containerColor = MaterialTheme.colorScheme.onPrimary,
-                              contentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContainerColor = Color.Gray),
-                      content = {
-                        Text(
-                            "Borrow item",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                      },
-                      modifier = Modifier.fillMaxWidth())
-                }
 
-                Spacer(modifier = Modifier.width(8.dp))
+                  // Displays the Edit button to the owner, and Borrow to someone else
+                  if (itemViewModel.compareIDs(
+                      item.idUser, FirebaseAuth.getInstance().currentUser?.uid)) {
 
-                // This should be displayed only if the user is the owner of the item
-                if (itemViewModel.compareIDs(
-                    item.idUser, FirebaseAuth.getInstance().currentUser?.uid)) {
-                  Button(
-                      onClick = { navigationActions.navigateTo(Route.EDIT_ITEM) },
-                      content = { Text("Edit") },
-                      colors =
-                          ButtonColors(
-                              containerColor = MaterialTheme.colorScheme.onPrimary,
-                              contentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContentColor = MaterialTheme.colorScheme.onBackground,
-                              disabledContainerColor = Color.Gray),
-                      modifier = Modifier.fillMaxWidth().testTag("editItemButton"))
+                    Button(
+                        onClick = { navigationActions.navigateTo(Route.EDIT_ITEM) },
+                        content = { Text("Edit") },
+                        modifier = Modifier.fillMaxWidth().testTag("editItemButton"))
+                  } else {
+                    Button(
+                        enabled = actualUser != user.id && actualUser != "" && user.id != "",
+                        onClick = {
+                          borrowViewModel.startBorrow(item, user)
+                          navigationActions.navigateTo(Route.BORROW)
+                        },
+                        content = { Text("Borrow item") },
+                        modifier = Modifier.fillMaxWidth())
+                  }
                 }
               }
             }

--- a/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/InventoryViewItemScreen.kt
@@ -152,7 +152,7 @@ fun InventoryViewItemScreen(
                 LabeledText(label = "Quantity", text = item.quantity.toString())
 
                 LabeledText(
-                    label = "Where",
+                    label = "Location",
                     text = item.location.extras?.getString("display_name", "Unknown") ?: "Unknown")
 
                 Row(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/com/android/partagix/ui/screens/ManageLoanRequestScreen.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ManageLoanRequestScreen.kt
@@ -73,7 +73,7 @@ fun ManageLoanRequest(
                 modifier =
                     modifier.padding(innerPadding).fillMaxSize().testTag("manageScreenNoItemBox")) {
                   Text(
-                      text = "There is no loan request.",
+                      text = "You have no loan request.",
                       modifier = modifier.align(Alignment.Center).testTag("manageScreenNoItemText"))
                 }
           }

--- a/app/src/main/java/com/android/partagix/ui/screens/ManageOutgoingLoan.kt
+++ b/app/src/main/java/com/android/partagix/ui/screens/ManageOutgoingLoan.kt
@@ -77,7 +77,7 @@ fun ManageOutgoingLoan(
                         .fillMaxSize()
                         .testTag("manageOutgoingScreenNoItemBox")) {
                   Text(
-                      text = "There is no outgoing loan request.",
+                      text = "You have no outgoing loan request.",
                       modifier = modifier.align(Alignment.Center).testTag("manageScreenNoItemText"))
                 }
           }


### PR DESCRIPTION
List of changes :
- Borrowing an item (ManageLoanScreen), replace the text _Make request reservation_ by _Request reservation_
- Replace _There is no item ...._ by _You have no item ..._
- View/Create/Edit/Borrow Item Screens: white buttons should be colored with the correct theme
- Create Item Screen: the Author field should be a LabeledText
- Create/Edit Item Screen + Edit Account : padding and color issues with Location Picker
- Position of the SearchBar on the Inventory Screen is too low. Make it higher
- Delete Visibility Friends Only
- Borrow Screen fields to LabeledText

As well as linked small problems fixed on the fly.